### PR TITLE
fix: prevent stale album images during album switch loading (#42) - depracated

### DIFF
--- a/src/features/dashboard/hooks/useDashboardData.ts
+++ b/src/features/dashboard/hooks/useDashboardData.ts
@@ -11,6 +11,7 @@ import type { AlbumImageListItem, AlbumRecord, StorageMeta } from '@/lib/storage
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react'
 import { toast } from 'sonner'
 import { useUpload } from '@/features/dashboard/hooks/useUpload'
+import { getIsInitialImagesLoading, getRenderableImages } from '@/features/dashboard/lib/imagesViewState'
 import { createAlbumFn, listAlbumsFn, moveAlbumFn, renameAlbumFn, setDefaultAlbumFn } from '@/functions/albums'
 import { deleteImageFn, deleteImagesFn, listImagesFn, moveImageFn, moveImagesFn, renameImageFn } from '@/functions/images'
 import { ROOT_ALBUM_ID } from '@/lib/storage/types'
@@ -64,7 +65,6 @@ export function useDashboardData() {
   const selectedAlbum = albumById.get(selectedAlbumId) ?? null
   const currentViewKey = `${selectedAlbumId}|${debouncedSearchQuery}`
   const hasLoadedCurrentView = loadedViewKeys.has(currentViewKey)
-  const hasLoadedAnyView = loadedViewKeys.size > 0
   const isSearchMode = debouncedSearchQuery.length > 0
   const totalCount = hasLoadedCurrentView
     ? images.length
@@ -73,7 +73,15 @@ export function useDashboardData() {
   const hasPreviousPage = pageIndex > 0
   const hasNextPage = totalPages !== null && pageIndex < totalPages - 1
   const isFetching = isImagesFetching || isViewTransitionPending
-  const isInitialLoading = !hasLoadedCurrentView && images.length === 0 && (!hasLoadedAnyView || imagesState === 'loading' || isImagesFetching)
+  const renderableImages = useMemo(() => getRenderableImages({
+    images,
+    hasLoadedCurrentView,
+  }), [hasLoadedCurrentView, images])
+  const isInitialLoading = getIsInitialImagesLoading({
+    hasLoadedCurrentView,
+    isFetching,
+    imagesState,
+  })
   const isPaginationBusy = isFetching
 
   useEffect(() => {
@@ -127,6 +135,7 @@ export function useDashboardData() {
     setImagesError(null)
     if (!hadLoadedView) {
       setImagesState('loading')
+      setImageUrlError(null)
     }
 
     try {
@@ -416,7 +425,7 @@ export function useDashboardData() {
   return {
     albums,
     albumById,
-    images,
+    images: renderableImages,
     imageUrlError,
     meta,
     selectedAlbumId,

--- a/src/features/dashboard/lib/imagesViewState.test.ts
+++ b/src/features/dashboard/lib/imagesViewState.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { getIsInitialImagesLoading, getRenderableImages } from './imagesViewState'
+
+describe('getRenderableImages', () => {
+  it('returns empty list when current view has not loaded to avoid stale album rows', () => {
+    const previousAlbumRows = [
+      { objectKey: 'a' },
+      { objectKey: 'b' },
+    ] as any
+
+    expect(getRenderableImages({ images: previousAlbumRows, hasLoadedCurrentView: false })).toEqual([])
+  })
+
+  it('returns existing rows once the current view has loaded', () => {
+    const currentAlbumRows = [{ objectKey: 'album-b-1' }] as any
+
+    expect(getRenderableImages({ images: currentAlbumRows, hasLoadedCurrentView: true })).toBe(currentAlbumRows)
+  })
+})
+
+describe('getIsInitialImagesLoading', () => {
+  it('returns true for an unloaded view while fetching', () => {
+    expect(getIsInitialImagesLoading({
+      hasLoadedCurrentView: false,
+      isFetching: true,
+      imagesState: 'idle',
+    })).toBe(true)
+  })
+
+  it('returns true for an unloaded view in loading state', () => {
+    expect(getIsInitialImagesLoading({
+      hasLoadedCurrentView: false,
+      isFetching: false,
+      imagesState: 'loading',
+    })).toBe(true)
+  })
+
+  it('returns false once current view has loaded even if a refetch is pending', () => {
+    expect(getIsInitialImagesLoading({
+      hasLoadedCurrentView: true,
+      isFetching: true,
+      imagesState: 'loading',
+    })).toBe(false)
+  })
+})

--- a/src/features/dashboard/lib/imagesViewState.test.ts
+++ b/src/features/dashboard/lib/imagesViewState.test.ts
@@ -3,16 +3,16 @@ import { getIsInitialImagesLoading, getRenderableImages } from './imagesViewStat
 
 describe('getRenderableImages', () => {
   it('returns empty list when current view has not loaded to avoid stale album rows', () => {
-    const previousAlbumRows = [
+    const previousAlbumRows: Array<{ objectKey: string }> = [
       { objectKey: 'a' },
       { objectKey: 'b' },
-    ] as any
+    ]
 
     expect(getRenderableImages({ images: previousAlbumRows, hasLoadedCurrentView: false })).toEqual([])
   })
 
   it('returns existing rows once the current view has loaded', () => {
-    const currentAlbumRows = [{ objectKey: 'album-b-1' }] as any
+    const currentAlbumRows: Array<{ objectKey: string }> = [{ objectKey: 'album-b-1' }]
 
     expect(getRenderableImages({ images: currentAlbumRows, hasLoadedCurrentView: true })).toBe(currentAlbumRows)
   })

--- a/src/features/dashboard/lib/imagesViewState.ts
+++ b/src/features/dashboard/lib/imagesViewState.ts
@@ -1,0 +1,32 @@
+import type { AlbumImageListItem } from '@/lib/storage/types'
+
+/**
+ * Returns the images that are safe to render for the active dashboard album/search view.
+ *
+ * When the active view has not been loaded yet, this returns an empty list to prevent
+ * rendering stale rows from a previously selected album while the new request is pending.
+ */
+export function getRenderableImages(input: {
+  images: AlbumImageListItem[]
+  hasLoadedCurrentView: boolean
+}): AlbumImageListItem[] {
+  return input.hasLoadedCurrentView ? input.images : []
+}
+
+/**
+ * Computes whether the dashboard should show the initial loading skeleton for the active view.
+ *
+ * The skeleton is shown for views that have not loaded successfully yet and are currently
+ * transitioning/fetching.
+ */
+export function getIsInitialImagesLoading(input: {
+  hasLoadedCurrentView: boolean
+  isFetching: boolean
+  imagesState: 'idle' | 'loading' | 'success' | 'error'
+}): boolean {
+  if (input.hasLoadedCurrentView) {
+    return false
+  }
+
+  return input.isFetching || input.imagesState === 'loading'
+}


### PR DESCRIPTION
### Motivation
- Switching albums could show images from the previously-selected album while the new album was loading because the dashboard hook continued to expose the previous `images` array during a pending view load. 
- The UX must show either cached images for the new album or a loading skeleton, and must never render images from a different album while fetching. 
- Keep logic in the dashboard data orchestration layer so routes/components stay thin and follow the repo patterns.

### Description
- Add pure view-state helpers in `src/features/dashboard/lib/imagesViewState.ts` to compute `getRenderableImages` and `getIsInitialImagesLoading` so rendering decisions are scoped to the active album/search view. 
- Update `src/features/dashboard/hooks/useDashboardData.ts` to return `images: renderableImages` (album-scoped) and to compute `isInitialLoading` from the new helpers, and clear prior `imageUrlError` when loading an uncached view. 
- Add unit tests in `src/features/dashboard/lib/imagesViewState.test.ts` that assert unloaded views do not return stale rows and that the initial-loading logic behaves correctly.

### Testing
- Ran unit tests with `pnpm test` (Vitest) and all tests passed. 
- Ran lint with `pnpm lint` (ESLint) and it passed without errors. 
- Ran a production build with `pnpm build` (Vite) and it completed successfully.

Closes #42

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f3ba7cb7c8327ae42d5578cd4f236)