### PR TITLE
fix: prevent stale album images during album switch loading (#42)

### DIFF
--- a/src/features/dashboard/hooks/useDashboardData.ts
+++ b/src/features/dashboard/hooks/useDashboardData.ts
@@ -11,6 +11,7 @@ import type { AlbumImageListItem, AlbumRecord, StorageMeta } from '@/lib/storage
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react'
 import { toast } from 'sonner'
 import { useUpload } from '@/features/dashboard/hooks/useUpload'
+import { getIsInitialImagesLoading, getRenderableImages } from '@/features/dashboard/lib/imagesViewState'
 import { createAlbumFn, listAlbumsFn, moveAlbumFn, renameAlbumFn, setDefaultAlbumFn } from '@/functions/albums'
 import { deleteImageFn, deleteImagesFn, listImagesFn, moveImageFn, moveImagesFn, renameImageFn } from '@/functions/images'
 import { ROOT_ALBUM_ID } from '@/lib/storage/types'
@@ -51,6 +52,7 @@ export function useDashboardData() {
   const [imagesReloadToken, setImagesReloadToken] = useState(0)
   const [isAlbumsLoaded, setIsAlbumsLoaded] = useState(false)
   const [loadedViewKeys, setLoadedViewKeys] = useState<Set<string>>(() => new Set())
+  const [currentImagesViewKey, setCurrentImagesViewKey] = useState<string | null>(null)
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
   const [renameImageObjectKey, setRenameImageObjectKey] = useState<string | null>(null)
   const [moveImageObjectKey, setMoveImageObjectKey] = useState<string | null>(null)
@@ -63,17 +65,24 @@ export function useDashboardData() {
   const albumById = useMemo(() => new Map(albums.map(album => [album.id, album])), [albums])
   const selectedAlbum = albumById.get(selectedAlbumId) ?? null
   const currentViewKey = `${selectedAlbumId}|${debouncedSearchQuery}`
-  const hasLoadedCurrentView = loadedViewKeys.has(currentViewKey)
-  const hasLoadedAnyView = loadedViewKeys.size > 0
+  const hasCurrentViewData = currentImagesViewKey === currentViewKey
   const isSearchMode = debouncedSearchQuery.length > 0
-  const totalCount = hasLoadedCurrentView
+  const totalCount = hasCurrentViewData
     ? images.length
     : (isSearchMode ? null : (selectedAlbum?.imageCount ?? 0))
   const totalPages = totalCount === null ? null : Math.max(1, Math.ceil(totalCount / pageSize))
   const hasPreviousPage = pageIndex > 0
   const hasNextPage = totalPages !== null && pageIndex < totalPages - 1
   const isFetching = isImagesFetching || isViewTransitionPending
-  const isInitialLoading = !hasLoadedCurrentView && images.length === 0 && (!hasLoadedAnyView || imagesState === 'loading' || isImagesFetching)
+  const renderableImages = useMemo(() => getRenderableImages({
+    images,
+    hasCurrentViewData,
+  }), [hasCurrentViewData, images])
+  const isInitialLoading = getIsInitialImagesLoading({
+    hasCurrentViewData,
+    isFetching,
+    imagesState,
+  })
   const isPaginationBusy = isFetching
 
   useEffect(() => {
@@ -127,6 +136,7 @@ export function useDashboardData() {
     setImagesError(null)
     if (!hadLoadedView) {
       setImagesState('loading')
+      setImageUrlError(null)
     }
 
     try {
@@ -162,6 +172,7 @@ export function useDashboardData() {
       setPageIndex(previous => Math.min(previous, nextLastPageIndex))
       setImages(items)
       setImageUrlError(viewImageUrlError)
+      setCurrentImagesViewKey(input.viewKey)
       setImagesState('success')
       setLoadedViewKeys((previous) => {
         if (previous.has(input.viewKey)) {
@@ -416,7 +427,7 @@ export function useDashboardData() {
   return {
     albums,
     albumById,
-    images,
+    images: renderableImages,
     imageUrlError,
     meta,
     selectedAlbumId,
@@ -460,7 +471,7 @@ export function useDashboardData() {
       state: imagesState,
       isFetching,
       isInitialLoading,
-      hasLoadedOnce: hasLoadedCurrentView,
+      hasLoadedOnce: hasCurrentViewData,
       error: imagesError,
     },
   }

--- a/src/features/dashboard/lib/imagesViewState.test.ts
+++ b/src/features/dashboard/lib/imagesViewState.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { getIsInitialImagesLoading, getRenderableImages } from './imagesViewState'
+
+describe('getRenderableImages', () => {
+  it('returns empty list when current rows belong to a different view', () => {
+    const previousAlbumRows = [
+      { objectKey: 'a' },
+      { objectKey: 'b' },
+    ] as any
+
+    expect(getRenderableImages({ images: previousAlbumRows, hasCurrentViewData: false })).toEqual([])
+  })
+
+  it('returns existing rows once rows belong to the active view key', () => {
+    const currentAlbumRows = [{ objectKey: 'album-b-1' }] as any
+
+    expect(getRenderableImages({ images: currentAlbumRows, hasCurrentViewData: true })).toBe(currentAlbumRows)
+  })
+})
+
+describe('getIsInitialImagesLoading', () => {
+  it('returns true when active view has no bound rows and fetch is pending', () => {
+    expect(getIsInitialImagesLoading({
+      hasCurrentViewData: false,
+      isFetching: true,
+      imagesState: 'idle',
+    })).toBe(true)
+  })
+
+  it('returns true when active view has no bound rows and state is loading', () => {
+    expect(getIsInitialImagesLoading({
+      hasCurrentViewData: false,
+      isFetching: false,
+      imagesState: 'loading',
+    })).toBe(true)
+  })
+
+  it('returns false when active view already has bound rows', () => {
+    expect(getIsInitialImagesLoading({
+      hasCurrentViewData: true,
+      isFetching: true,
+      imagesState: 'loading',
+    })).toBe(false)
+  })
+})

--- a/src/features/dashboard/lib/imagesViewState.ts
+++ b/src/features/dashboard/lib/imagesViewState.ts
@@ -1,0 +1,32 @@
+import type { AlbumImageListItem } from '@/lib/storage/types'
+
+/**
+ * Returns the images that are safe to render for the active dashboard album/search view.
+ *
+ * The `images` array only represents one loaded view at a time, so rows are renderable only
+ * when that loaded payload belongs to the currently selected view key.
+ */
+export function getRenderableImages(input: {
+  images: AlbumImageListItem[]
+  hasCurrentViewData: boolean
+}): AlbumImageListItem[] {
+  return input.hasCurrentViewData ? input.images : []
+}
+
+/**
+ * Computes whether the dashboard should show the initial loading skeleton for the active view.
+ *
+ * The skeleton is shown whenever the active view does not yet have rows bound to it and a fetch
+ * (or transition-triggered fetch) is in progress.
+ */
+export function getIsInitialImagesLoading(input: {
+  hasCurrentViewData: boolean
+  isFetching: boolean
+  imagesState: 'idle' | 'loading' | 'success' | 'error'
+}): boolean {
+  if (input.hasCurrentViewData) {
+    return false
+  }
+
+  return input.isFetching || input.imagesState === 'loading'
+}


### PR DESCRIPTION
### Motivation
- Switching between albums could briefly render rows from the previously selected album when returning (A → B → A) because the shared `images` array was not tied to the active view key, so a skeleton was not shown for the returning view.

### Description
- Track which `viewKey` currently owns the loaded `images` payload by adding `currentImagesViewKey` and set it when a fetch completes so rows are owned by a specific view key.
- Gate rendering on active-view ownership by computing `hasCurrentViewData = currentImagesViewKey === currentViewKey` and expose `images: renderableImages` computed via the `getRenderableImages` helper.
- Move initial-loading logic to `getIsInitialImagesLoading` and wire `hasCurrentViewData` into `imagesStatus.hasLoadedOnce` so skeleton vs data semantics follow active-view ownership.
- Rename/update the view-state helpers and update unit tests in `src/features/dashboard/lib/imagesViewState.*` to cover the active-view ownership scenario.

### Testing
- Ran unit tests with `pnpm test` and all tests passed.
- Ran lint with `pnpm lint` and it completed successfully.
- Built production with `pnpm build` and the build succeeded.
- `pnpm dev` manual browser verification was blocked in this environment because Wrangler remote mode requires login.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f3ba7cb7c8327ae42d5578cd4f236)