### PR TITLE
perf(images): avoid redundant refreshes and retain source files

### DIFF
--- a/src/features/dashboard/hooks/useDashboardData.ts
+++ b/src/features/dashboard/hooks/useDashboardData.ts
@@ -30,6 +30,11 @@ const SEARCH_DEBOUNCE_MS = 250
 
 type ImagesState = 'idle' | 'loading' | 'success' | 'error'
 
+interface ImageViewCacheEntry {
+  items: AlbumImageListItem[]
+  imageUrlError: string | null
+}
+
 /**
  * Central dashboard data orchestration for albums, full image datasets, and mutations.
  *
@@ -48,7 +53,6 @@ export function useDashboardData() {
   const [pageSize, setPageSize] = useState(DEFAULT_IMAGE_PAGE_SIZE)
   const [searchQuery, setSearchQuery] = useState('')
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('')
-  const [imagesReloadToken, setImagesReloadToken] = useState(0)
   const [isAlbumsLoaded, setIsAlbumsLoaded] = useState(false)
   const [loadedViewKeys, setLoadedViewKeys] = useState<Set<string>>(() => new Set())
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
@@ -57,12 +61,15 @@ export function useDashboardData() {
   const [pendingDeleteObjectKey, setPendingDeleteObjectKey] = useState<string | null>(null)
   const [isViewTransitionPending, startViewTransition] = useTransition()
   const imageRequestIdRef = useRef(0)
+  const activeImagesRef = useRef(images)
   const selectedAlbumIdRef = useRef(selectedAlbumId)
   const loadedViewKeysRef = useRef(loadedViewKeys)
+  const imageViewsRef = useRef(new Map<string, ImageViewCacheEntry>())
 
   const albumById = useMemo(() => new Map(albums.map(album => [album.id, album])), [albums])
   const selectedAlbum = albumById.get(selectedAlbumId) ?? null
   const currentViewKey = `${selectedAlbumId}|${debouncedSearchQuery}`
+  const activeViewKeyRef = useRef(currentViewKey)
   const hasLoadedCurrentView = loadedViewKeys.has(currentViewKey)
   const hasLoadedAnyView = loadedViewKeys.size > 0
   const isSearchMode = debouncedSearchQuery.length > 0
@@ -81,8 +88,16 @@ export function useDashboardData() {
   }, [selectedAlbumId])
 
   useEffect(() => {
+    activeImagesRef.current = images
+  }, [images])
+
+  useEffect(() => {
     loadedViewKeysRef.current = loadedViewKeys
   }, [loadedViewKeys])
+
+  useEffect(() => {
+    activeViewKeyRef.current = currentViewKey
+  }, [currentViewKey])
 
   const fetchImagesPage = useCallback(async (input: {
     albumId: string
@@ -121,11 +136,24 @@ export function useDashboardData() {
   }) => {
     const requestId = imageRequestIdRef.current + 1
     imageRequestIdRef.current = requestId
+    const cached = imageViewsRef.current.get(input.viewKey)
+    if (cached !== undefined) {
+      activeImagesRef.current = cached.items
+      setImages(cached.items)
+      setImageUrlError(cached.imageUrlError)
+      setImagesError(null)
+      setImagesState('success')
+      setIsImagesFetching(false)
+      return
+    }
+
     const hadLoadedView = loadedViewKeysRef.current.has(input.viewKey)
 
     setIsImagesFetching(true)
     setImagesError(null)
     if (!hadLoadedView) {
+      activeImagesRef.current = []
+      setImages([])
       setImagesState('loading')
     }
 
@@ -160,9 +188,14 @@ export function useDashboardData() {
       const nextPageCount = Math.max(1, Math.ceil(items.length / pageSize))
       const nextLastPageIndex = Math.max(0, nextPageCount - 1)
       setPageIndex(previous => Math.min(previous, nextLastPageIndex))
+      activeImagesRef.current = items
       setImages(items)
       setImageUrlError(viewImageUrlError)
       setImagesState('success')
+      imageViewsRef.current.set(input.viewKey, {
+        items,
+        imageUrlError: viewImageUrlError,
+      })
       setLoadedViewKeys((previous) => {
         if (previous.has(input.viewKey)) {
           return previous
@@ -187,15 +220,106 @@ export function useDashboardData() {
     }
   }, [fetchImagesPage, pageSize])
 
-  const refreshAlbum = useCallback(async (albumId: string) => {
-    await loadAlbums(albumId)
-    setPageIndex(0)
-    setImagesReloadToken(token => token + 1)
-  }, [loadAlbums])
+  const updateImageView = useCallback((input: {
+    viewKey: string
+    updater: (items: AlbumImageListItem[]) => AlbumImageListItem[]
+    clampPage?: boolean
+  }) => {
+    const cached = imageViewsRef.current.get(input.viewKey)
+    if (cached !== undefined) {
+      imageViewsRef.current.set(input.viewKey, {
+        ...cached,
+        items: input.updater(cached.items),
+      })
+    }
+
+    if (activeViewKeyRef.current === input.viewKey) {
+      const next = input.updater(activeImagesRef.current)
+      activeImagesRef.current = next
+      setImages(next)
+      if (input.clampPage) {
+        const lastPageIndex = Math.max(0, Math.ceil(next.length / pageSize) - 1)
+        setPageIndex(current => Math.min(current, lastPageIndex))
+      }
+    }
+  }, [pageSize])
+
+  const removeImagesFromCachedViews = useCallback((input: {
+    objectKeys: readonly string[]
+    viewKey: string
+  }) => {
+    const keys = new Set(input.objectKeys)
+    for (const [viewKey, cached] of imageViewsRef.current) {
+      imageViewsRef.current.set(viewKey, {
+        ...cached,
+        items: cached.items.filter(image => !keys.has(image.objectKey)),
+      })
+    }
+    updateImageView({
+      viewKey: input.viewKey,
+      updater: images => images.filter(image => !keys.has(image.objectKey)),
+      clampPage: true,
+    })
+  }, [updateImageView])
+
+  const invalidateInactiveImageViews = useCallback(() => {
+    const activeViewKey = activeViewKeyRef.current
+    for (const viewKey of imageViewsRef.current.keys()) {
+      if (viewKey !== activeViewKey) {
+        imageViewsRef.current.delete(viewKey)
+      }
+    }
+    setLoadedViewKeys(previous => new Set([...previous].filter(viewKey => viewKey === activeViewKey)))
+  }, [])
+
+  const updateAlbumUsage = useCallback((changes: Map<string, { imageCount: number, bytesUsed: number }>) => {
+    setAlbums(previous => previous.map((album) => {
+      const change = changes.get(album.id)
+      if (change === undefined) {
+        return album
+      }
+      return {
+        ...album,
+        imageCount: Math.max(0, album.imageCount + change.imageCount),
+        bytesUsed: Math.max(0, album.bytesUsed + change.bytesUsed),
+      }
+    }))
+  }, [])
 
   const { isUploading, uploadFiles } = useUpload({
     selectedAlbumId,
-    onUploaded: refreshAlbum,
+    onUploaded: (uploaded) => {
+      const uploadViewKey = currentViewKey
+      invalidateInactiveImageViews()
+      const matching = uploaded
+        .filter(({ albumImage }) => albumImage.albumId === selectedAlbumId)
+        .map(({ albumImage, publicUrl }) => ({ ...albumImage, publicUrl }))
+        .filter(image => debouncedSearchQuery.length === 0 || image.nameLower.includes(debouncedSearchQuery.toLowerCase()))
+
+      if (matching.length > 0) {
+        updateImageView({
+          viewKey: uploadViewKey,
+          updater: images => [...matching, ...images],
+        })
+      }
+
+      const usage = new Map<string, { imageCount: number, bytesUsed: number }>()
+      for (const { albumImage } of uploaded) {
+        const current = usage.get(albumImage.albumId) ?? { imageCount: 0, bytesUsed: 0 }
+        current.imageCount += 1
+        current.bytesUsed += albumImage.sizeBytes
+        usage.set(albumImage.albumId, current)
+      }
+      updateAlbumUsage(usage)
+      setMeta(previous => previous === null
+        ? previous
+        : {
+            ...previous,
+            totalImageCount: previous.totalImageCount + uploaded.length,
+            totalBytesUsed: previous.totalBytesUsed + uploaded.reduce((total, { albumImage }) => total + albumImage.sizeBytes, 0),
+            updatedAt: new Date().toISOString(),
+          })
+    },
   })
 
   useEffect(() => {
@@ -244,7 +368,7 @@ export function useDashboardData() {
         description: error instanceof Error ? error.message : String(error),
       })
     })
-  }, [currentViewKey, debouncedSearchQuery, imagesReloadToken, isAlbumsLoaded, loadImages, selectedAlbumId])
+  }, [currentViewKey, debouncedSearchQuery, isAlbumsLoaded, loadImages, selectedAlbumId])
 
   const createAlbum = useCallback(async ({ name, parentId }: CreateAlbumInput) => {
     const payload = await createAlbumFn({
@@ -254,41 +378,47 @@ export function useDashboardData() {
       },
     })
 
-    await refreshAlbum(payload.album.id)
+    setAlbums(payload.albums)
+    setMeta(payload.meta)
+    setSelectedAlbumId(payload.album.id)
     toast.success('Album created')
-  }, [refreshAlbum])
+  }, [])
 
   const renameAlbum = useCallback(async ({ albumId, name }: RenameAlbumInput) => {
-    await renameAlbumFn({
+    const payload = await renameAlbumFn({
       data: {
         albumId,
         name: name.trim(),
       },
     })
 
-    await loadAlbums(albumId)
+    setAlbums(payload.albums)
+    setMeta(payload.meta)
     toast.success('Album renamed')
-  }, [loadAlbums])
+  }, [])
 
   const moveAlbum = useCallback(async ({ albumId, parentId }: MoveAlbumInput) => {
-    await moveAlbumFn({
+    const payload = await moveAlbumFn({
       data: {
         albumId,
         parentId,
       },
     })
 
-    await loadAlbums(albumId)
+    setAlbums(payload.albums)
+    setMeta(payload.meta)
     toast.success('Album moved')
-  }, [loadAlbums])
+  }, [])
 
   const setDefaultAlbum = useCallback(async (albumId: string) => {
-    await setDefaultAlbumFn({ data: { albumId } })
-    await loadAlbums(albumId)
+    const payload = await setDefaultAlbumFn({ data: { albumId } })
+    setMeta(payload.meta)
     toast.success('Default album updated')
-  }, [loadAlbums])
+  }, [])
 
   const moveImage = useCallback(async ({ objectKey, targetAlbumId }: MoveImageInput) => {
+    const viewKey = currentViewKey
+    const sourceImage = images.find(image => image.objectKey === objectKey)
     await moveImageFn({
       data: {
         objectKey,
@@ -296,52 +426,118 @@ export function useDashboardData() {
       },
     })
 
-    await refreshAlbum(selectedAlbumId)
+    if (sourceImage !== undefined && sourceImage.albumId !== targetAlbumId) {
+      removeImagesFromCachedViews({ objectKeys: [objectKey], viewKey })
+      invalidateInactiveImageViews()
+      updateAlbumUsage(new Map([
+        [sourceImage.albumId, { imageCount: -1, bytesUsed: -sourceImage.sizeBytes }],
+        [targetAlbumId, { imageCount: 1, bytesUsed: sourceImage.sizeBytes }],
+      ]))
+    }
     setMoveImageObjectKey(null)
     toast.success('Image moved')
-  }, [refreshAlbum, selectedAlbumId])
+  }, [currentViewKey, images, invalidateInactiveImageViews, removeImagesFromCachedViews, updateAlbumUsage])
 
   const renameImage = useCallback(async ({ objectKey, name }: RenameImageInput) => {
-    await renameImageFn({
+    const viewKey = currentViewKey
+    const query = debouncedSearchQuery.toLowerCase()
+    const payload = await renameImageFn({
       data: {
         objectKey,
         name: name.trim(),
       },
     })
-    await refreshAlbum(selectedAlbumId)
+    updateImageView({
+      viewKey,
+      updater: images => images.flatMap((image) => {
+        if (image.objectKey !== objectKey) {
+          return [image]
+        }
+        const renamed = {
+          ...image,
+          name: payload.image.name,
+          nameLower: payload.image.name.toLowerCase(),
+        }
+        return query.length === 0 || renamed.nameLower.includes(query) ? [renamed] : []
+      }),
+      clampPage: true,
+    })
+    invalidateInactiveImageViews()
     setRenameImageObjectKey(null)
     toast.success('Image renamed')
-  }, [refreshAlbum, selectedAlbumId])
+  }, [currentViewKey, debouncedSearchQuery, invalidateInactiveImageViews, updateImageView])
 
   const deleteImage = useCallback(async (objectKey: string) => {
-    await deleteImageFn({ data: { objectKey } })
-    await refreshAlbum(selectedAlbumId)
+    const viewKey = currentViewKey
+    const payload = await deleteImageFn({ data: { objectKey } })
+    removeImagesFromCachedViews({ objectKeys: [objectKey], viewKey })
+    invalidateInactiveImageViews()
+    updateAlbumUsage(new Map([[
+      payload.image.albumId,
+      { imageCount: -1, bytesUsed: -payload.image.sizeBytes },
+    ]]))
+    setMeta(previous => previous === null
+      ? previous
+      : {
+          ...previous,
+          totalImageCount: Math.max(0, previous.totalImageCount - 1),
+          totalBytesUsed: Math.max(0, previous.totalBytesUsed - payload.image.sizeBytes),
+          updatedAt: new Date().toISOString(),
+        })
     setPendingDeleteObjectKey(null)
     toast.success('Image deleted')
-  }, [refreshAlbum, selectedAlbumId])
+  }, [currentViewKey, invalidateInactiveImageViews, removeImagesFromCachedViews, updateAlbumUsage])
 
   const bulkMoveImages = useCallback(async ({ objectKeys, targetAlbumId }: BulkMoveImagesInput): Promise<BulkOperationResult> => {
+    const viewKey = currentViewKey
     const result = await moveImagesFn({
       data: {
         objectKeys,
         targetAlbumId,
       },
     })
-    await refreshAlbum(selectedAlbumId)
+    const sourceImages = images.filter(image => result.succeededObjectKeys.includes(image.objectKey))
+    if (targetAlbumId !== selectedAlbumId && sourceImages.length > 0) {
+      removeImagesFromCachedViews({ objectKeys: result.succeededObjectKeys, viewKey })
+      invalidateInactiveImageViews()
+      const bytesUsed = sourceImages.reduce((total, image) => total + image.sizeBytes, 0)
+      updateAlbumUsage(new Map([
+        [selectedAlbumId, { imageCount: -sourceImages.length, bytesUsed: -bytesUsed }],
+        [targetAlbumId, { imageCount: sourceImages.length, bytesUsed }],
+      ]))
+    }
 
     return result
-  }, [refreshAlbum, selectedAlbumId])
+  }, [currentViewKey, images, invalidateInactiveImageViews, removeImagesFromCachedViews, selectedAlbumId, updateAlbumUsage])
 
   const bulkDeleteImages = useCallback(async (objectKeys: string[]): Promise<BulkOperationResult> => {
+    const viewKey = currentViewKey
     const result = await deleteImagesFn({
       data: {
         objectKeys,
       },
     })
-    await refreshAlbum(selectedAlbumId)
+    const deletedImages = images.filter(image => result.succeededObjectKeys.includes(image.objectKey))
+    removeImagesFromCachedViews({ objectKeys: result.succeededObjectKeys, viewKey })
+    invalidateInactiveImageViews()
+    if (deletedImages.length > 0) {
+      const bytesUsed = deletedImages.reduce((total, image) => total + image.sizeBytes, 0)
+      updateAlbumUsage(new Map([[
+        selectedAlbumId,
+        { imageCount: -deletedImages.length, bytesUsed: -bytesUsed },
+      ]]))
+      setMeta(previous => previous === null
+        ? previous
+        : {
+            ...previous,
+            totalImageCount: Math.max(0, previous.totalImageCount - deletedImages.length),
+            totalBytesUsed: Math.max(0, previous.totalBytesUsed - bytesUsed),
+            updatedAt: new Date().toISOString(),
+          })
+    }
 
     return result
-  }, [refreshAlbum, selectedAlbumId])
+  }, [currentViewKey, images, invalidateInactiveImageViews, removeImagesFromCachedViews, selectedAlbumId, updateAlbumUsage])
 
   const goNextPage = useCallback(() => {
     if (isPaginationBusy || !hasNextPage) {

--- a/src/features/dashboard/hooks/useUpload.ts
+++ b/src/features/dashboard/hooks/useUpload.ts
@@ -1,3 +1,4 @@
+import type { AlbumImageRecord, ImageRecord } from '@/lib/storage/types'
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
 import { uploadImageFn } from '@/functions/images'
@@ -5,7 +6,13 @@ import { getImageDimensions } from '@/lib/images/dimensions'
 
 interface UseUploadOptions {
   selectedAlbumId: string
-  onUploaded: (albumId: string) => Promise<void>
+  onUploaded: (uploaded: UploadedImage[]) => void
+}
+
+export interface UploadedImage {
+  image: ImageRecord
+  albumImage: AlbumImageRecord
+  publicUrl: string | null
 }
 
 /**
@@ -32,6 +39,7 @@ export function useUpload(options: UseUploadOptions) {
 
     setIsUploading(true)
     try {
+      const uploaded: UploadedImage[] = []
       for (const file of Array.from(files)) {
         const dimensions = await getImageDimensions(file)
         if (dimensions === null) {
@@ -48,10 +56,10 @@ export function useUpload(options: UseUploadOptions) {
           formData.set('width', String(dimensions.width))
           formData.set('height', String(dimensions.height))
         }
-        await uploadImageFn({ data: formData })
+        uploaded.push(await uploadImageFn({ data: formData }))
       }
 
-      await onUploaded(selectedAlbumId)
+      onUploaded(uploaded)
       toast.success(`${files.length} image(s) uploaded`)
     }
     catch (error) {

--- a/src/features/home/components/ResultRow.tsx
+++ b/src/features/home/components/ResultRow.tsx
@@ -43,6 +43,11 @@ function ConversionBadge({ status, originalFormat, targetFormat }: ConversionBad
           </Badge>
         </>
       )}
+      {status === 'original' && (
+        <Badge variant="outline" className="shrink-0 border-amber-600 text-amber-700">
+          Original kept
+        </Badge>
+      )}
       {status === 'error' && (
         <Badge variant="destructive" className="shrink-0">Error</Badge>
       )}
@@ -64,9 +69,9 @@ export function ResultRow({
   onRemove,
   onRetryTransform,
 }: ResultRowProps) {
-  const compressedSize = item.compressedSize
+  const compressedSize = item.outputSize
   const isCompressed = item.status === 'compressed' && compressedSize !== null
-  const isSelectable = item.status === 'compressed' && item.compressedFile !== null
+  const isOutputAvailable = (item.status === 'compressed' || item.status === 'original') && item.outputFile !== null
   const savedPercent = isCompressed && item.originalSize > 0
     ? ((item.originalSize - compressedSize) / item.originalSize) * 100
     : 0
@@ -83,7 +88,7 @@ export function ResultRow({
             <Checkbox
               aria-label={`Select ${item.originalName}`}
               checked={isSelected}
-              disabled={selectionDisabled || !isSelectable}
+              disabled={selectionDisabled || !isOutputAvailable}
               onCheckedChange={checked => onToggleSelected(checked === true)}
               className="h-5 w-5 rounded-md"
             />
@@ -104,19 +109,19 @@ export function ResultRow({
               <p className="truncate text-sm font-medium">{baseName(item.originalName)}</p>
               <p className="text-xs text-muted-foreground">
                 {getHumanReadableFileSize(item.originalSize)}
-                {item.compressedSize !== null && (
+                {isCompressed && item.outputSize !== null && (
                   <>
                     {' '}
                     {'->'}
                     {' '}
-                    {getHumanReadableFileSize(item.compressedSize)}
+                    {getHumanReadableFileSize(item.outputSize)}
                   </>
                 )}
               </p>
             </div>
 
             <div className="flex shrink-0 items-center gap-1 self-start">
-              {isCompressed && (
+              {isOutputAvailable && (
                 <Button
                   type="button"
                   size="icon"
@@ -171,10 +176,15 @@ export function ResultRow({
             {sizeLabel !== null && (
               <span className={`wrap-break-word ${sizeLabelClass}`}>{sizeLabel}</span>
             )}
+            {item.status === 'original' && (
+              <span className="wrap-break-word text-amber-700 dark:text-amber-400">
+                Converted output was not smaller.
+              </span>
+            )}
           </div>
 
           {item.transformError !== null && item.transformError.length > 0 && (
-            <p className="flex items-start gap-1 text-xs text-destructive">
+            <p className={`flex items-start gap-1 text-xs ${item.status === 'original' ? 'text-amber-700 dark:text-amber-400' : 'text-destructive'}`}>
               <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
               <span className="wrap-break-word">{item.transformError}</span>
             </p>

--- a/src/features/home/components/ResultsList.tsx
+++ b/src/features/home/components/ResultsList.tsx
@@ -66,7 +66,8 @@ export function ResultsList({
   }
 
   const transformedCount = items.filter(item => item.status === 'compressed').length
-  const hasDownloadables = transformedCount > 0
+  const retainedOriginalCount = items.filter(item => item.status === 'original').length
+  const hasDownloadables = items.some(item => item.outputFile !== null)
 
   return (
     <section aria-label="Processed image list" className="min-w-0 space-y-3">
@@ -80,6 +81,17 @@ export function ResultsList({
             {transformedCount}
             {' '}
             compressed
+            {retainedOriginalCount > 0 && (
+              <>
+                {' · '}
+                {retainedOriginalCount}
+                {' '}
+                original
+                {retainedOriginalCount === 1 ? '' : 's'}
+                {' '}
+                kept
+              </>
+            )}
           </p>
           {isCompressing && (
             <p className="flex items-center gap-1 text-xs text-muted-foreground">
@@ -122,7 +134,7 @@ export function ResultsList({
             <>
               <label className="flex items-center gap-2 text-xs text-muted-foreground">
                 <Checkbox
-                  aria-label="Select all compressed rows"
+                  aria-label="Select all processed rows"
                   checked={isIndeterminate ? 'indeterminate' : isAllSelected}
                   disabled={selectionDisabled || selectableCount === 0}
                   onCheckedChange={checked => onToggleAll(checked === true)}

--- a/src/features/home/components/UploadSelectedDialog.tsx
+++ b/src/features/home/components/UploadSelectedDialog.tsx
@@ -43,7 +43,7 @@ export function UploadSelectedDialog({
           <DialogDescription>
             {isPending
               ? `Uploading ${selectedCount} image(s)...`
-              : `Choose an album and upload ${selectedCount} compressed image(s).`}
+              : `Choose an album and upload ${selectedCount} processed image(s).`}
           </DialogDescription>
         </DialogHeader>
 

--- a/src/features/home/hooks/useCompressedDownloads.ts
+++ b/src/features/home/hooks/useCompressedDownloads.ts
@@ -3,13 +3,8 @@ import JSZip from 'jszip'
 import { useCallback, useTransition } from 'react'
 import { toast } from 'sonner'
 
-function fileBaseName(name: string): string {
-  const value = name.split('.').slice(0, -1).join('.').trim()
-  return value.length > 0 ? value : name
-}
-
 /**
- * Provides single-file and zip download actions for compressed home rows.
+ * Provides single-file and zip download actions for processed home rows.
  *
  * @param items Current processed home rows.
  * @returns Pending state and callbacks for download actions.
@@ -18,12 +13,12 @@ export function useCompressedDownloads(items: readonly HomeProcessedItem[]) {
   const [downloadingAll, startDownloadingAll] = useTransition()
 
   const downloadOne = useCallback((item: HomeProcessedItem) => {
-    if (item.compressedBlob === null) {
+    if (item.outputFile === null) {
       return
     }
 
-    const url = URL.createObjectURL(item.compressedBlob)
-    const fileName = `${fileBaseName(item.originalName)}.${item.targetFormat}`
+    const url = URL.createObjectURL(item.outputFile)
+    const fileName = item.outputFile.name
     const link = document.createElement('a')
     link.href = url
     link.download = fileName
@@ -36,19 +31,18 @@ export function useCompressedDownloads(items: readonly HomeProcessedItem[]) {
 
   const downloadAll = useCallback(() => {
     startDownloadingAll(async () => {
-      const transformed = items.filter(item => item.compressedBlob !== null)
+      const transformed = items.filter(item => item.outputFile !== null)
       if (transformed.length === 0) {
-        toast.error('No compressed images available to download')
+        toast.error('No processed images available to download')
         return
       }
 
       const zip = new JSZip()
       for (const item of transformed) {
-        if (!item.compressedBlob) {
+        if (!item.outputFile) {
           continue
         }
-        const fileName = `${fileBaseName(item.originalName)}.${item.targetFormat}`
-        zip.file(fileName, item.compressedBlob)
+        zip.file(item.outputFile.name, item.outputFile)
       }
 
       const zipBlob = await zip.generateAsync({ type: 'blob' })
@@ -60,7 +54,7 @@ export function useCompressedDownloads(items: readonly HomeProcessedItem[]) {
       link.click()
       document.body.removeChild(link)
       URL.revokeObjectURL(url)
-      toast.success('Downloaded compressed image zip')
+      toast.success('Downloaded processed image zip')
     })
   }, [items, startDownloadingAll])
 

--- a/src/features/home/hooks/useImageTransformQueue.ts
+++ b/src/features/home/hooks/useImageTransformQueue.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { getImageDimensions } from '@/lib/images/dimensions'
 import { checkImage, normalizeTransformError, transformImageFile } from '@/lib/img'
+import { shouldKeepOriginalImage } from '@/lib/img/output'
 import { normalizeImageMime } from '@/lib/storage/format'
 
 function fileBaseName(name: string): string {
@@ -70,9 +71,9 @@ export function useImageTransformQueue() {
           originalPreviewUrl: URL.createObjectURL(file),
           originalFormat: normalizeImageMime(extension, file.type).replace('image/', ''),
           targetFormat,
-          compressedBlob: null,
-          compressedFile: null,
-          compressedSize: null,
+          outputBlob: null,
+          outputFile: null,
+          outputSize: null,
           width: null,
           height: null,
           status: 'idle',
@@ -119,14 +120,38 @@ export function useImageTransformQueue() {
       originalName: item.originalName,
       targetFormat,
     })
+
+    if (shouldKeepOriginalImage({
+      originalSize: item.originalSize,
+      outputSize: blob.size,
+    })) {
+      const dimensions = await getImageDimensions(item.originalFile)
+      return {
+        ...item,
+        targetFormat,
+        outputBlob: item.originalFile,
+        outputFile: item.originalFile,
+        outputSize: item.originalSize,
+        width: dimensions?.width ?? null,
+        height: dimensions?.height ?? null,
+        status: 'original',
+        transformError: 'The original file was kept.',
+        uploadStatus: 'idle',
+        uploadError: null,
+        uploadedUrl: null,
+        uploadedObjectKey: null,
+        uploadedAlbumId: null,
+      }
+    }
+
     const dimensions = await getImageDimensions(compressedFile)
 
     return {
       ...item,
       targetFormat,
-      compressedBlob: blob,
-      compressedFile,
-      compressedSize: blob.size,
+      outputBlob: blob,
+      outputFile: compressedFile,
+      outputSize: blob.size,
       width: dimensions?.width ?? null,
       height: dimensions?.height ?? null,
       status: 'compressed',
@@ -150,6 +175,7 @@ export function useImageTransformQueue() {
 
     let succeeded = 0
     let failed = 0
+    let retainedOriginals = 0
 
     for (let index = 0; index < itemsRef.current.length; index += 1) {
       const current = itemsRef.current[index]
@@ -162,6 +188,9 @@ export function useImageTransformQueue() {
       try {
         const transformed = await transformOne(current)
         patchItem(current.id, transformed)
+        if (transformed.status === 'original') {
+          retainedOriginals += 1
+        }
         succeeded += 1
       }
       catch (error) {
@@ -169,9 +198,9 @@ export function useImageTransformQueue() {
         patchItem(current.id, {
           status: 'error',
           transformError: normalized.message,
-          compressedBlob: null,
-          compressedFile: null,
-          compressedSize: null,
+          outputBlob: null,
+          outputFile: null,
+          outputSize: null,
           width: null,
           height: null,
           uploadStatus: 'idle',
@@ -188,7 +217,14 @@ export function useImageTransformQueue() {
     }
 
     if (succeeded > 0 && failed === 0) {
-      toast.success('Images compressed successfully')
+      if (retainedOriginals > 0) {
+        toast.warning('Some original files were kept', {
+          description: `${retainedOriginals} conversion(s) would have increased file size.`,
+        })
+      }
+      else {
+        toast.success('Images compressed successfully')
+      }
       setCompressionState('success')
       return
     }
@@ -226,9 +262,9 @@ export function useImageTransformQueue() {
       patchItem(id, {
         status: 'error',
         transformError: normalized.message,
-        compressedBlob: null,
-        compressedFile: null,
-        compressedSize: null,
+        outputBlob: null,
+        outputFile: null,
+        outputSize: null,
         width: null,
         height: null,
         uploadStatus: 'idle',

--- a/src/features/home/hooks/useSelection.ts
+++ b/src/features/home/hooks/useSelection.ts
@@ -2,7 +2,10 @@ import type { HomeProcessedItem } from '@/features/home/types'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 function isSelectable(item: HomeProcessedItem): boolean {
-  return item.status === 'compressed' && item.compressedFile !== null
+  return (
+    (item.status === 'compressed' || item.status === 'original')
+    && item.outputFile !== null
+  )
 }
 
 function isSameSelection(previous: Set<string>, nextIds: readonly string[]): boolean {

--- a/src/features/home/hooks/useUploadSelected.ts
+++ b/src/features/home/hooks/useUploadSelected.ts
@@ -244,8 +244,8 @@ export function useUploadSelected(
   const uploadCandidates = useMemo(() => {
     return items.filter(item => (
       selectedIds.has(item.id)
-      && item.status === 'compressed'
-      && item.compressedFile !== null
+      && (item.status === 'compressed' || item.status === 'original')
+      && item.outputFile !== null
       && item.uploadStatus !== 'uploaded'
     ))
   }, [items, selectedIds])
@@ -277,10 +277,10 @@ export function useUploadSelected(
         candidates,
         async (item) => {
           try {
-            const file = item.compressedFile
+            const file = item.outputFile
 
             if (!file) {
-              throw new Error('Missing compressed output file')
+              throw new Error('Missing processed output file')
             }
 
             const formData = new FormData()
@@ -428,7 +428,7 @@ export function useUploadSelected(
 
     if (uploadCandidates.length === 0) {
       toast.error(
-        'No selected compressed images to upload',
+        'No selected processed images to upload',
       )
       return
     }

--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -1,7 +1,7 @@
 /**
  * Lifecycle state for one image compression task.
  */
-export type TransformStatus = 'idle' | 'compressing' | 'compressed' | 'error'
+export type TransformStatus = 'idle' | 'compressing' | 'compressed' | 'original' | 'error'
 
 /**
  * Lifecycle state for one image upload task.
@@ -29,9 +29,10 @@ export interface HomeProcessedItem {
   originalPreviewUrl: string
   originalFormat: string
   targetFormat: SupportedFormat
-  compressedBlob: Blob | null
-  compressedFile: File | null
-  compressedSize: number | null
+  /** Final file to download or upload. It can be the source file when conversion is larger. */
+  outputBlob: Blob | null
+  outputFile: File | null
+  outputSize: number | null
   width: number | null
   height: number | null
   status: TransformStatus

--- a/src/functions/images.ts
+++ b/src/functions/images.ts
@@ -11,7 +11,7 @@ import { requireAuth } from '@/lib/auth/guards'
 import { runBulkOperation } from '@/lib/bulk'
 import { getD1Binding, getR2Binding } from '@/lib/cloudflare/bindings'
 import { buildPublicImageUrl, getR2PublicDomain } from '@/lib/cloudflare/publicUrl'
-import { getAlbumRecord } from '@/lib/storage/albumsRepo'
+import { albumExists } from '@/lib/storage/albumsRepo'
 import { normalizeImageExt, normalizeImageMime, toStoredName } from '@/lib/storage/format'
 import { deriveDefaultImageName, resolveImageName } from '@/lib/storage/imageName'
 import {
@@ -76,8 +76,7 @@ export const listImagesFn = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     await requireAuth()
     const db = getD1Binding()
-    const album = await getAlbumRecord(db, data.albumId)
-    if (!album) {
+    if (!(await albumExists(db, data.albumId))) {
       throw new Error('Album not found')
     }
 
@@ -139,8 +138,7 @@ export const uploadImageFn = createServerFn({ method: 'POST' })
     const albumId = String(data.get('albumId') ?? '').trim()
     uploadDashboardSchema.parse({ albumId })
 
-    const album = await getAlbumRecord(db, albumId)
-    if (!album) {
+    if (!(await albumExists(db, albumId))) {
       throw new Error('Album not found')
     }
 
@@ -235,8 +233,7 @@ export const moveImageFn = createServerFn({ method: 'POST' })
       return { image }
     }
 
-    const targetAlbum = await getAlbumRecord(db, data.targetAlbumId)
-    if (!targetAlbum) {
+    if (!(await albumExists(db, data.targetAlbumId))) {
       throw new Error('Target album not found')
     }
 
@@ -257,8 +254,7 @@ export const moveImagesFn = createServerFn({ method: 'POST' })
     await requireAuth()
     const db = getD1Binding()
 
-    const targetAlbum = await getAlbumRecord(db, data.targetAlbumId)
-    if (!targetAlbum) {
+    if (!(await albumExists(db, data.targetAlbumId))) {
       throw new Error('Target album not found')
     }
 
@@ -330,7 +326,7 @@ export const deleteImageFn = createServerFn({ method: 'POST' })
     }
 
     await deleteImageRecords(db, image)
-    return true
+    return { image }
   })
 
 /**

--- a/src/lib/img/output.test.ts
+++ b/src/lib/img/output.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { shouldKeepOriginalImage } from './output'
+
+describe('shouldKeepOriginalImage', () => {
+  it('keeps the source when conversion increases the file size', () => {
+    expect(shouldKeepOriginalImage({ originalSize: 100, outputSize: 101 })).toBe(true)
+  })
+
+  it('keeps the source when conversion does not save bytes', () => {
+    expect(shouldKeepOriginalImage({ originalSize: 100, outputSize: 100 })).toBe(true)
+  })
+
+  it('uses transformed output only when it is smaller', () => {
+    expect(shouldKeepOriginalImage({ originalSize: 100, outputSize: 99 })).toBe(false)
+  })
+})

--- a/src/lib/img/output.ts
+++ b/src/lib/img/output.ts
@@ -1,0 +1,17 @@
+/**
+ * Determines whether a transformed image should replace its source file.
+ *
+ * A same-sized output offers no storage benefit and can introduce an
+ * unnecessary lossy conversion, so the source remains the final file.
+ *
+ * @param input Source and transformed byte sizes.
+ * @param input.originalSize Source file size in bytes.
+ * @param input.outputSize Transformed file size in bytes.
+ * @returns `true` when the source file should be kept.
+ */
+export function shouldKeepOriginalImage(input: {
+  originalSize: number
+  outputSize: number
+}): boolean {
+  return input.outputSize >= input.originalSize
+}

--- a/src/lib/storage/albumsRepo.ts
+++ b/src/lib/storage/albumsRepo.ts
@@ -94,8 +94,10 @@ function buildPathResolver(rows: Array<{ id: string, parentId: string | null }>)
 }
 
 async function listAlbumRecordsInternal(): Promise<AlbumRecord[]> {
-  const rows = await loadAlbumRows()
-  const usageById = await loadAlbumUsageById()
+  const [rows, usageById] = await Promise.all([
+    loadAlbumRows(),
+    loadAlbumUsageById(),
+  ])
   const resolvePath = buildPathResolver(rows.map(row => ({ id: row.id, parentId: row.parentId })))
 
   return rows
@@ -243,13 +245,42 @@ export async function getAlbumRecord(_db: D1Database, albumId: string): Promise<
 }
 
 /**
+ * Checks whether an album exists without loading the complete album tree or
+ * aggregating image usage.
+ *
+ * @param _db D1 database binding.
+ * @param albumId Album identifier.
+ * @returns `true` when the album exists.
+ */
+export async function albumExists(_db: D1Database, albumId: string): Promise<boolean> {
+  const db = getDb()
+  const [album] = await db
+    .select({ id: albumsTable.id })
+    .from(albumsTable)
+    .where(eq(albumsTable.id, albumId))
+    .limit(1)
+
+  if (album !== undefined || albumId !== ROOT_ALBUM_ID) {
+    return album !== undefined
+  }
+
+  // Direct image endpoints can be the first storage request. Initialize only
+  // the root row on that uncommon path instead of rebuilding usage metadata.
+  await ensureRootAlbum()
+  return true
+}
+
+/**
  * Lists all albums sorted by depth then name for stable tree rendering.
  *
  * @param _db D1 database binding.
  * @returns Sorted flat album list.
+ *
+ * The caller must initialize storage with `ensureStorageBootstrap` before
+ * listing. Server handlers already perform that initialization once per
+ * request, avoiding duplicate D1 reads for the same snapshot.
  */
 export async function listAlbumRecords(_db: D1Database): Promise<AlbumRecord[]> {
-  await ensureStorageBootstrap(_db)
   return listAlbumRecordsInternal()
 }
 


### PR DESCRIPTION
### Description

Reduce redundant D1 and server reads in image workflows while retaining source files when conversion does not save bytes.

### Refactor Changes

- [x] Code optimization: cache dashboard image views and apply mutation results locally instead of reloading albums and images.
- [x] Improve maintainability: keep the authenticated React Query album cache while reusing one output-file field for transformed and retained sources.
- [x] Remove unnecessary code: replace full album-tree validation with a lightweight existence query, with a root-only first-use safeguard.

### Bug Fixes

- [x] Fixed issue: keep and expose the original file when transformed output is the same size or larger.
- [x] Fixed issue: clear pending state when returning to a cached dashboard view.
- [x] Performance fix: invalidate stale image requests and prevent asynchronous mutations from updating the wrong view.

### Verification

- [x] `pnpm lint`
- [x] TypeScript check: `pnpm exec tsc --noEmit`
- [x] `pnpm test` (8 tests)
- [x] `pnpm build`
- [x] Local SSR smoke check for `/`; protected `/dashboard` redirects to `/login` when unauthenticated.

### Risks / Follow-up

- No schema or dependency changes. Full authenticated upload and dashboard mutation flows should be exercised against a configured local D1/R2 environment before release.

### AGENTS.md Update

- Updated: N/A
- Breaking: No
- Migration: N/A
- New env var/binding: N/A
- Deprecated pattern: full dashboard refetch after image mutation -> targeted local state update and inactive-view invalidation.
