### PR TITLE
fix(home): improve copy and action feedback

### DIFF
--- a/src/features/dashboard/lib/copyFormats.test.ts
+++ b/src/features/dashboard/lib/copyFormats.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { buildImageCopyLines } from './copyFormats'
+
+describe('buildImageCopyLines', () => {
+  it('uses the filename without its extension as Markdown alt text', () => {
+    const lines = buildImageCopyLines([
+      {
+        name: '[summer.photo].webp',
+        publicUrl: 'https://images.example/summer.photo.webp',
+      },
+    ], 'markdown')
+
+    expect(lines).toEqual([
+      '![\\[summer.photo\\]](https://images.example/summer.photo.webp)',
+    ])
+  })
+})

--- a/src/features/dashboard/lib/copyFormats.ts
+++ b/src/features/dashboard/lib/copyFormats.ts
@@ -1,3 +1,5 @@
+import { withoutExtension } from '@/lib/storage/format'
+
 export type ImageCopyFormat = 'direct' | 'html' | 'markdown'
 
 /**
@@ -47,7 +49,7 @@ export const IMAGE_COPY_FORMATS: readonly ImageCopyFormatMeta[] = [
 ] as const
 
 function toMarkdownAlt(name: string): string {
-  return name.replaceAll('[', '\\[').replaceAll(']', '\\]')
+  return withoutExtension(name).replaceAll('[', '\\[').replaceAll(']', '\\]')
 }
 
 function toHtmlAlt(name: string): string {

--- a/src/features/home/components/HomeFeature.tsx
+++ b/src/features/home/components/HomeFeature.tsx
@@ -28,6 +28,7 @@ export function HomeFeature() {
     setUseManualQuality,
     compressionState,
     compressedCount,
+    isTransforming,
     addImages,
     removeItem,
     transformAll,
@@ -58,7 +59,7 @@ export function HomeFeature() {
   })
 
   const isUploading = uploadState === 'uploading'
-  const isActionLocked = isCompressing || isUploading
+  const isActionLocked = isTransforming || isUploading
 
   const copyItems = useMemo(() => {
     return items.map(item => ({

--- a/src/features/home/components/UploadedLinksPanel.tsx
+++ b/src/features/home/components/UploadedLinksPanel.tsx
@@ -43,11 +43,15 @@ export function UploadedLinksPanel({
         <CardDescription>
           {uploadedCount}
           {' '}
-          uploaded ·
-          {' '}
-          {selectedUploadedCount}
-          {' '}
-          selected uploaded
+          uploaded
+          {selectedUploadedCount > 0 && (
+            <>
+              {' · '}
+              {selectedUploadedCount}
+              {' '}
+              selected uploaded
+            </>
+          )}
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-wrap gap-2">

--- a/src/features/home/hooks/useImageTransformQueue.ts
+++ b/src/features/home/hooks/useImageTransformQueue.ts
@@ -38,6 +38,7 @@ export function useImageTransformQueue() {
   const [useManualQuality, setUseManualQuality] = useState(false)
   const [compressionState, setCompressionState] = useState<CompressionState>('idle')
   const [compressedCount, setCompressedCount] = useState(0)
+  const [isTransforming, setIsTransforming] = useState(false)
   const itemsRef = useRef<HomeProcessedItem[]>([])
   const isTransformingRef = useRef(false)
 
@@ -175,9 +176,10 @@ export function useImageTransformQueue() {
 
     /*
      * State updates do not disable the button until React's next render. Keep
-     * this synchronous guard so rapid clicks cannot start overlapping batches.
+     * this synchronous guard so rapid clicks cannot start overlapping transforms.
      */
     isTransformingRef.current = true
+    setIsTransforming(true)
 
     try {
       setCompressionState('compressing')
@@ -252,15 +254,23 @@ export function useImageTransformQueue() {
     }
     finally {
       isTransformingRef.current = false
+      setIsTransforming(false)
     }
   }, [patchItem, transformOne])
 
   const retryTransform = useCallback(async (id: string) => {
+    if (isTransformingRef.current) {
+      return
+    }
+
     const target = itemsRef.current.find(item => item.id === id)
     if (!target) {
       return
     }
 
+    isTransformingRef.current = true
+    setIsTransforming(true)
+    setCompressionState('idle')
     patchItem(id, {
       status: 'compressing',
       transformError: null,
@@ -270,6 +280,7 @@ export function useImageTransformQueue() {
       const transformed = await transformOne(target)
       patchItem(id, transformed)
       toast.success(`Recompressed ${target.originalName}`)
+      setCompressionState('success')
     }
     catch (error) {
       const normalized = normalizeTransformError(error)
@@ -290,6 +301,11 @@ export function useImageTransformQueue() {
       toast.error(`Failed to recompress ${target.originalName}`, {
         description: normalized.message,
       })
+      setCompressionState('error')
+    }
+    finally {
+      isTransformingRef.current = false
+      setIsTransforming(false)
     }
   }, [patchItem, transformOne])
 
@@ -303,6 +319,7 @@ export function useImageTransformQueue() {
     setUseManualQuality,
     compressionState,
     compressedCount,
+    isTransforming,
     addImages,
     removeItem,
     transformAll,

--- a/src/features/home/hooks/useImageTransformQueue.ts
+++ b/src/features/home/hooks/useImageTransformQueue.ts
@@ -39,6 +39,7 @@ export function useImageTransformQueue() {
   const [compressionState, setCompressionState] = useState<CompressionState>('idle')
   const [compressedCount, setCompressedCount] = useState(0)
   const itemsRef = useRef<HomeProcessedItem[]>([])
+  const isTransformingRef = useRef(false)
 
   useEffect(() => {
     itemsRef.current = items
@@ -165,80 +166,93 @@ export function useImageTransformQueue() {
   }, [quality, targetFormat, useManualQuality])
 
   const transformAll = useCallback(async () => {
-    if (itemsRef.current.length === 0) {
-      toast.error('Please add some images first')
+    if (isTransformingRef.current || itemsRef.current.length === 0) {
+      if (itemsRef.current.length === 0) {
+        toast.error('Please add some images first')
+      }
       return
     }
 
-    setCompressionState('compressing')
-    setCompressedCount(0)
+    /*
+     * State updates do not disable the button until React's next render. Keep
+     * this synchronous guard so rapid clicks cannot start overlapping batches.
+     */
+    isTransformingRef.current = true
 
-    let succeeded = 0
-    let failed = 0
-    let retainedOriginals = 0
+    try {
+      setCompressionState('compressing')
+      setCompressedCount(0)
 
-    for (let index = 0; index < itemsRef.current.length; index += 1) {
-      const current = itemsRef.current[index]
+      let succeeded = 0
+      let failed = 0
+      let retainedOriginals = 0
 
-      patchItem(current.id, {
-        status: 'compressing',
-        transformError: null,
-      })
+      for (let index = 0; index < itemsRef.current.length; index += 1) {
+        const current = itemsRef.current[index]
 
-      try {
-        const transformed = await transformOne(current)
-        patchItem(current.id, transformed)
-        if (transformed.status === 'original') {
-          retainedOriginals += 1
-        }
-        succeeded += 1
-      }
-      catch (error) {
-        const normalized = normalizeTransformError(error)
         patchItem(current.id, {
-          status: 'error',
-          transformError: normalized.message,
-          outputBlob: null,
-          outputFile: null,
-          outputSize: null,
-          width: null,
-          height: null,
-          uploadStatus: 'idle',
-          uploadError: null,
-          uploadedUrl: null,
-          uploadedObjectKey: null,
-          uploadedAlbumId: null,
+          status: 'compressing',
+          transformError: null,
         })
-        failed += 1
-      }
-      finally {
-        setCompressedCount(index + 1)
-      }
-    }
 
-    if (succeeded > 0 && failed === 0) {
-      if (retainedOriginals > 0) {
-        toast.warning('Some original files were kept', {
-          description: `${retainedOriginals} conversion(s) would have increased file size.`,
+        try {
+          const transformed = await transformOne(current)
+          patchItem(current.id, transformed)
+          if (transformed.status === 'original') {
+            retainedOriginals += 1
+          }
+          succeeded += 1
+        }
+        catch (error) {
+          const normalized = normalizeTransformError(error)
+          patchItem(current.id, {
+            status: 'error',
+            transformError: normalized.message,
+            outputBlob: null,
+            outputFile: null,
+            outputSize: null,
+            width: null,
+            height: null,
+            uploadStatus: 'idle',
+            uploadError: null,
+            uploadedUrl: null,
+            uploadedObjectKey: null,
+            uploadedAlbumId: null,
+          })
+          failed += 1
+        }
+        finally {
+          setCompressedCount(index + 1)
+        }
+      }
+
+      if (succeeded > 0 && failed === 0) {
+        if (retainedOriginals > 0) {
+          toast.warning('Some original files were kept', {
+            description: `${retainedOriginals} conversion(s) would have increased file size.`,
+          })
+        }
+        else {
+          toast.success('Images compressed successfully')
+        }
+        setCompressionState('success')
+        return
+      }
+
+      if (succeeded > 0 && failed > 0) {
+        toast.warning('Compression partially completed', {
+          description: `${succeeded} succeeded, ${failed} failed.`,
         })
+        setCompressionState('error')
+        return
       }
-      else {
-        toast.success('Images compressed successfully')
-      }
-      setCompressionState('success')
-      return
-    }
 
-    if (succeeded > 0 && failed > 0) {
-      toast.warning('Compression partially completed', {
-        description: `${succeeded} succeeded, ${failed} failed.`,
-      })
+      toast.error('Failed to compress images')
       setCompressionState('error')
-      return
     }
-
-    toast.error('Failed to compress images')
-    setCompressionState('error')
+    finally {
+      isTransformingRef.current = false
+    }
   }, [patchItem, transformOne])
 
   const retryTransform = useCallback(async (id: string) => {

--- a/src/features/home/hooks/useUploadSelected.ts
+++ b/src/features/home/hooks/useUploadSelected.ts
@@ -13,6 +13,7 @@ import {
   useCallback,
   useMemo,
   useReducer,
+  useRef,
   useState,
 } from 'react'
 import { toast } from 'sonner'
@@ -211,6 +212,7 @@ export function useUploadSelected(
     uploadProgressReducer,
     INITIAL_UPLOAD_PROGRESS,
   )
+  const isUploadStartingRef = useRef(false)
 
   const albumsQuery = useQuery({
     queryKey: albumQueryKeys.list(),
@@ -398,6 +400,10 @@ export function useUploadSelected(
           : String(error),
       })
     },
+
+    onSettled: () => {
+      isUploadStartingRef.current = false
+    },
   })
 
   const setUploadDialogOpen = useCallback(
@@ -406,7 +412,7 @@ export function useUploadSelected(
        * Do not allow the user to dismiss the dialog while the active batch is
        * still writing item state.
        */
-      if (!open && uploadMutation.isPending) {
+      if (!open && (isUploadStartingRef.current || uploadMutation.isPending)) {
         return
       }
 
@@ -422,7 +428,7 @@ export function useUploadSelected(
   )
 
   const uploadSelected = useCallback(() => {
-    if (!enabled || uploadMutation.isPending) {
+    if (!enabled || isUploadStartingRef.current || uploadMutation.isPending) {
       return
     }
 
@@ -442,6 +448,7 @@ export function useUploadSelected(
      * Take a snapshot so later queue or selection changes do not alter the
      * currently running upload batch.
      */
+    isUploadStartingRef.current = true
     uploadMutation.mutate({
       albumId: selectedAlbumId,
       candidates: [...uploadCandidates],


### PR DESCRIPTION
### 📌 Description

Fixes three home/dashboard image workflow issues:
- Markdown copied from image links now uses the filename without its extension as alt text.
- Transform, retry, and upload actions are single-flight so rapid clicks cannot start duplicate work.
- The uploaded-links summary hides the selected count when it is zero.

### 🔍 Feature Changes

- [x] UI/UX improvement
- [ ] API update

### 🔄 Refactor Changes

- [x] Improve maintainability

### 🛠 Bug Fixes

- [x] Fixed duplicate action submissions
- [x] Added a Markdown copy-format regression test

### ✅ Checklist

- [x] Code follows project coding style.
- [x] Relevant tests pass.
- [x] Production build passes.
- [x] No breaking changes introduced.

### 📜 Dependency Changes

None.

### 📝 Steps to Reproduce (before fix)

1. Copy an image as Markdown and observe the extension in the alt text.
2. Rapidly click Compress, Retry, or Upload selected.
3. Upload images without selecting an uploaded item.

### 💬 Additional Notes

Manual browser verification was unavailable because the local browser automation binary is not installed.