### PR TITLE
fix(storage): harden deletion and upload boundaries

### DIFF
--- a/migrations/0002_image_cleanup_tombstones.sql
+++ b/migrations/0002_image_cleanup_tombstones.sql
@@ -1,0 +1,7 @@
+ALTER TABLE images ADD COLUMN deleted_at INTEGER NULL;
+ALTER TABLE images ADD COLUMN cleanup_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE images ADD COLUMN cleanup_error TEXT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_images_pending_cleanup
+  ON images(deleted_at ASC, id ASC)
+  WHERE deleted_at IS NOT NULL;

--- a/src/features/dashboard/hooks/useDashboardData.ts
+++ b/src/features/dashboard/hooks/useDashboardData.ts
@@ -485,7 +485,12 @@ export function useDashboardData() {
           updatedAt: new Date().toISOString(),
         })
     setPendingDeleteObjectKey(null)
-    toast.success('Image deleted')
+    if (payload.cleanupPending) {
+      toast.warning('Image hidden; storage cleanup will retry automatically')
+    }
+    else {
+      toast.success('Image deleted')
+    }
   }, [currentViewKey, invalidateInactiveImageViews, removeImagesFromCachedViews, updateAlbumUsage])
 
   const bulkMoveImages = useCallback(async ({ objectKeys, targetAlbumId }: BulkMoveImagesInput): Promise<BulkOperationResult> => {
@@ -534,6 +539,10 @@ export function useDashboardData() {
             totalBytesUsed: Math.max(0, previous.totalBytesUsed - bytesUsed),
             updatedAt: new Date().toISOString(),
           })
+    }
+
+    if (result.cleanupPendingObjectKeys.length > 0) {
+      toast.warning(`${result.cleanupPendingObjectKeys.length} image cleanup(s) will retry automatically`)
     }
 
     return result

--- a/src/functions/images.ts
+++ b/src/functions/images.ts
@@ -11,11 +11,12 @@ import { requireAuth } from '@/lib/auth/guards'
 import { runBulkOperation } from '@/lib/bulk'
 import { getD1Binding, getR2Binding } from '@/lib/cloudflare/bindings'
 import { buildPublicImageUrl, getR2PublicDomain } from '@/lib/cloudflare/publicUrl'
+import { validateUploadImage } from '@/lib/images/uploadValidation'
 import { albumExists } from '@/lib/storage/albumsRepo'
 import { normalizeImageExt, normalizeImageMime, toStoredName } from '@/lib/storage/format'
+import { deleteImageSafely, reconcilePendingImageDeletes } from '@/lib/storage/imageCleanup'
 import { deriveDefaultImageName, resolveImageName } from '@/lib/storage/imageName'
 import {
-  deleteImageRecords,
   getImageRecord,
   listAlbumImages,
   moveImageRecords,
@@ -34,17 +35,6 @@ import {
 
 const BULK_OPERATION_CONCURRENCY = 4
 const BULK_OPERATION_TIMEOUT_MS = 20_000
-
-function parseNumberField(value: FormDataEntryValue | null): number | null {
-  if (typeof value !== 'string' || value.trim().length === 0) {
-    return null
-  }
-  const parsed = Number(value)
-  if (!Number.isFinite(parsed)) {
-    return null
-  }
-  return parsed
-}
 
 function normalizeDimensionValue(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null
@@ -76,6 +66,10 @@ export const listImagesFn = createServerFn({ method: 'POST' })
   .handler(async ({ data }) => {
     await requireAuth()
     const db = getD1Binding()
+    const r2 = getR2Binding()
+    await reconcilePendingImageDeletes({ db, r2 }).catch((error) => {
+      console.error('[listImagesFn] Failed to reconcile pending image deletions:', error)
+    })
     if (!(await albumExists(db, data.albumId))) {
       throw new Error('Album not found')
     }
@@ -147,17 +141,16 @@ export const uploadImageFn = createServerFn({ method: 'POST' })
       throw new TypeError('File is required')
     }
 
+    const validatedFile = await validateUploadImage(fileEntry)
     const originalName = String(data.get('originalName') ?? fileEntry.name).trim() || fileEntry.name
     const source = sourceFrom(data.get('source'))
-    const ext = normalizeImageExt(fileEntry.name, fileEntry.type)
-    const mime = normalizeImageMime(ext, fileEntry.type)
+    const ext = normalizeImageExt(fileEntry.name, validatedFile.mime)
+    const mime = normalizeImageMime(ext, validatedFile.mime)
     const storedName = toStoredName(originalName, ext)
     const objectKey = buildR2ObjectKey({ ext })
     const imageName = deriveDefaultImageName(originalName, objectKey)
     const uploadedAt = new Date().toISOString()
-    const bytes = await fileEntry.arrayBuffer()
-    const width = parseNumberField(data.get('width'))
-    const height = parseNumberField(data.get('height'))
+    const { bytes, width, height } = validatedFile
 
     await putImageObject(r2, {
       key: objectKey,
@@ -319,14 +312,11 @@ export const deleteImageFn = createServerFn({ method: 'POST' })
     const db = getD1Binding()
     const r2 = getR2Binding()
     const image = await getImageRecord(db, data.objectKey)
-
-    await deleteImageObject(r2, data.objectKey)
     if (!image) {
       throw new Error('Image not found')
     }
 
-    await deleteImageRecords(db, image)
-    return { image }
+    return deleteImageSafely({ db, r2, image })
   })
 
 /**
@@ -342,13 +332,11 @@ export const deleteImagesFn = createServerFn({ method: 'POST' })
 
     const result = await runBulkOperation(objectKeys, async (objectKey) => {
       const image = await getImageRecord(db, objectKey)
-
-      await deleteImageObject(r2, objectKey)
       if (!image) {
         throw new Error('Image not found')
       }
 
-      await deleteImageRecords(db, image)
+      return deleteImageSafely({ db, r2, image })
     }, {
       concurrency: BULK_OPERATION_CONCURRENCY,
       timeoutMs: BULK_OPERATION_TIMEOUT_MS,
@@ -365,6 +353,9 @@ export const deleteImagesFn = createServerFn({ method: 'POST' })
       succeeded: result.ok.length,
       failed: result.failed.length,
       succeededObjectKeys: result.ok.map(item => item.item),
+      cleanupPendingObjectKeys: result.ok
+        .filter(item => item.result.cleanupPending)
+        .map(item => item.item),
       failedItems: result.failed.map(failure => ({
         objectKey: failure.item,
         reason: failure.error.message,

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -35,10 +35,14 @@ export const imagesTable = sqliteTable('images', {
   source: text('source', {
     enum: ['index-compressed', 'dashboard-upload'],
   }).notNull(),
+  deletedAt: integer('deleted_at'),
+  cleanupAttempts: integer('cleanup_attempts').notNull().default(0),
+  cleanupError: text('cleanup_error'),
 }, table => [
   index('idx_images_album_created_desc').on(table.albumId, table.createdAt, table.id),
   index('idx_images_album_name_lower').on(table.albumId, table.nameLower),
   index('idx_images_created_desc').on(table.createdAt, table.id),
+  index('idx_images_pending_cleanup').on(table.deletedAt, table.id),
 ])
 
 export type AlbumRow = typeof albumsTable.$inferSelect

--- a/src/lib/images/uploadValidation.test.ts
+++ b/src/lib/images/uploadValidation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { MAX_UPLOAD_SIZE_BYTES, parseUploadImage, validateUploadImage } from './uploadValidation'
+
+function png(width: number, height: number): Uint8Array {
+  return new Uint8Array([
+    0x89,
+    0x50,
+    0x4E,
+    0x47,
+    0x0D,
+    0x0A,
+    0x1A,
+    0x0A,
+    0x00,
+    0x00,
+    0x00,
+    0x0D,
+    0x49,
+    0x48,
+    0x44,
+    0x52,
+    (width >>> 24) & 0xFF,
+    (width >>> 16) & 0xFF,
+    (width >>> 8) & 0xFF,
+    width & 0xFF,
+    (height >>> 24) & 0xFF,
+    (height >>> 16) & 0xFF,
+    (height >>> 8) & 0xFF,
+    height & 0xFF,
+  ])
+}
+
+describe('uploadValidation', () => {
+  it('derives PNG dimensions and canonical MIME from binary content', () => {
+    expect(parseUploadImage(png(1200, 800))).toEqual({
+      mime: 'image/png',
+      width: 1200,
+      height: 800,
+    })
+  })
+
+  it('rejects malformed headers and unsafe image dimensions', () => {
+    expect(parseUploadImage(new Uint8Array([0x89, 0x50, 0x4E, 0x47]))).toBeNull()
+    expect(parseUploadImage(png(32_769, 10))).toBeNull()
+  })
+
+  it('rejects a browser-declared MIME that does not match the file content', async () => {
+    const file = new File([png(10, 10).buffer as ArrayBuffer], 'image.jpg', { type: 'image/jpeg' })
+
+    await expect(validateUploadImage(file)).rejects.toThrow('does not match')
+  })
+
+  it('uses binary metadata instead of the upload filename', async () => {
+    const file = new File([png(640, 480).buffer as ArrayBuffer], 'image.svg', { type: 'image/png' })
+
+    await expect(validateUploadImage(file)).resolves.toMatchObject({
+      mime: 'image/png',
+      width: 640,
+      height: 480,
+    })
+  })
+
+  it('rejects files that exceed the server upload size limit before decoding', async () => {
+    const file = new File([new ArrayBuffer(MAX_UPLOAD_SIZE_BYTES + 1)], 'large.png', { type: 'image/png' })
+
+    await expect(validateUploadImage(file)).rejects.toThrow('exceeds 10 MiB')
+  })
+})

--- a/src/lib/images/uploadValidation.ts
+++ b/src/lib/images/uploadValidation.ts
@@ -1,0 +1,292 @@
+/** Maximum accepted upload size at the server trust boundary (10 MiB). */
+export const MAX_UPLOAD_SIZE_BYTES = 10 * 1024 * 1024
+
+const MAX_IMAGE_DIMENSION = 32_768
+const MAX_IMAGE_PIXELS = 100_000_000
+const JPEG_START_OF_FRAME_MARKERS = new Set([
+  0xC0,
+  0xC1,
+  0xC2,
+  0xC3,
+  0xC5,
+  0xC6,
+  0xC7,
+  0xC9,
+  0xCA,
+  0xCB,
+  0xCD,
+  0xCE,
+  0xCF,
+])
+
+export type UploadImageMime
+  = | 'image/avif'
+    | 'image/bmp'
+    | 'image/gif'
+    | 'image/jpeg'
+    | 'image/png'
+    | 'image/webp'
+
+export interface ValidatedUploadImage {
+  bytes: ArrayBuffer
+  mime: UploadImageMime
+  width: number
+  height: number
+}
+
+interface ParsedUploadImage {
+  mime: UploadImageMime
+  width: number
+  height: number
+}
+
+function readU16BE(bytes: Uint8Array, offset: number): number | null {
+  if (offset < 0 || offset + 2 > bytes.length) {
+    return null
+  }
+  return (bytes[offset] << 8) | bytes[offset + 1]
+}
+
+function readU16LE(bytes: Uint8Array, offset: number): number | null {
+  if (offset < 0 || offset + 2 > bytes.length) {
+    return null
+  }
+  return bytes[offset] | (bytes[offset + 1] << 8)
+}
+
+function readU24LE(bytes: Uint8Array, offset: number): number | null {
+  if (offset < 0 || offset + 3 > bytes.length) {
+    return null
+  }
+  return bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16)
+}
+
+function readU32BE(bytes: Uint8Array, offset: number): number | null {
+  if (offset < 0 || offset + 4 > bytes.length) {
+    return null
+  }
+  return ((bytes[offset] * 2 ** 24) + (bytes[offset + 1] << 16) + (bytes[offset + 2] << 8) + bytes[offset + 3]) >>> 0
+}
+
+function readI32LE(bytes: Uint8Array, offset: number): number | null {
+  if (offset < 0 || offset + 4 > bytes.length) {
+    return null
+  }
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getInt32(offset, true)
+}
+
+function hasAscii(bytes: Uint8Array, offset: number, value: string): boolean {
+  if (offset < 0 || offset + value.length > bytes.length) {
+    return false
+  }
+  return [...value].every((character, index) => bytes[offset + index] === character.charCodeAt(0))
+}
+
+function toDimensions(width: number | null, height: number | null): { width: number, height: number } | null {
+  if (
+    width === null
+    || height === null
+    || width < 1
+    || height < 1
+    || width > MAX_IMAGE_DIMENSION
+    || height > MAX_IMAGE_DIMENSION
+    || width * height > MAX_IMAGE_PIXELS
+  ) {
+    return null
+  }
+  return { width, height }
+}
+
+function parsePng(bytes: Uint8Array): ParsedUploadImage | null {
+  if (
+    bytes.length < 24
+    || bytes[0] !== 0x89
+    || !hasAscii(bytes, 1, 'PNG')
+    || bytes[4] !== 0x0D
+    || bytes[5] !== 0x0A
+    || bytes[6] !== 0x1A
+    || bytes[7] !== 0x0A
+    || !hasAscii(bytes, 12, 'IHDR')
+  ) {
+    return null
+  }
+  const dimensions = toDimensions(readU32BE(bytes, 16), readU32BE(bytes, 20))
+  return dimensions === null ? null : { mime: 'image/png', ...dimensions }
+}
+
+function parseGif(bytes: Uint8Array): ParsedUploadImage | null {
+  if (!hasAscii(bytes, 0, 'GIF87a') && !hasAscii(bytes, 0, 'GIF89a')) {
+    return null
+  }
+  const dimensions = toDimensions(readU16LE(bytes, 6), readU16LE(bytes, 8))
+  return dimensions === null ? null : { mime: 'image/gif', ...dimensions }
+}
+
+function parseBmp(bytes: Uint8Array): ParsedUploadImage | null {
+  if (bytes[0] !== 0x42 || bytes[1] !== 0x4D) {
+    return null
+  }
+  const height = readI32LE(bytes, 22)
+  const dimensions = toDimensions(readI32LE(bytes, 18), height === null ? null : Math.abs(height))
+  return dimensions === null ? null : { mime: 'image/bmp', ...dimensions }
+}
+
+function parseJpeg(bytes: Uint8Array): ParsedUploadImage | null {
+  if (bytes[0] !== 0xFF || bytes[1] !== 0xD8 || bytes[2] !== 0xFF) {
+    return null
+  }
+
+  let offset = 2
+  while (offset + 9 < bytes.length) {
+    if (bytes[offset] !== 0xFF) {
+      offset += 1
+      continue
+    }
+
+    while (bytes[offset] === 0xFF) {
+      offset += 1
+    }
+    const marker = bytes[offset]
+    offset += 1
+
+    if (marker === undefined || marker === 0xD8 || marker === 0xD9 || (marker >= 0xD0 && marker <= 0xD7)) {
+      continue
+    }
+
+    const segmentLength = readU16BE(bytes, offset)
+    if (segmentLength === null || segmentLength < 2 || offset + segmentLength > bytes.length) {
+      return null
+    }
+
+    if (JPEG_START_OF_FRAME_MARKERS.has(marker)) {
+      const dimensions = toDimensions(readU16BE(bytes, offset + 5), readU16BE(bytes, offset + 3))
+      return dimensions === null ? null : { mime: 'image/jpeg', ...dimensions }
+    }
+
+    offset += segmentLength
+  }
+
+  return null
+}
+
+function parseWebp(bytes: Uint8Array): ParsedUploadImage | null {
+  if (!hasAscii(bytes, 0, 'RIFF') || !hasAscii(bytes, 8, 'WEBP')) {
+    return null
+  }
+
+  if (hasAscii(bytes, 12, 'VP8X')) {
+    const width = readU24LE(bytes, 24)
+    const height = readU24LE(bytes, 27)
+    const dimensions = toDimensions(width === null ? null : width + 1, height === null ? null : height + 1)
+    return dimensions === null ? null : { mime: 'image/webp', ...dimensions }
+  }
+
+  if (hasAscii(bytes, 12, 'VP8L') && bytes[20] === 0x2F) {
+    const packed = readU32BE(bytes, 21)
+    if (packed === null) {
+      return null
+    }
+    const littleEndianPacked = ((packed & 0xFF) << 24) | ((packed & 0xFF00) << 8) | ((packed >>> 8) & 0xFF00) | ((packed >>> 24) & 0xFF)
+    const dimensions = toDimensions((littleEndianPacked & 0x3FFF) + 1, ((littleEndianPacked >>> 14) & 0x3FFF) + 1)
+    return dimensions === null ? null : { mime: 'image/webp', ...dimensions }
+  }
+
+  if (hasAscii(bytes, 12, 'VP8') && bytes[23] === 0x9D && bytes[24] === 0x01 && bytes[25] === 0x2A) {
+    const width = readU16LE(bytes, 26)
+    const height = readU16LE(bytes, 28)
+    const dimensions = toDimensions(width === null ? null : width & 0x3FFF, height === null ? null : height & 0x3FFF)
+    return dimensions === null ? null : { mime: 'image/webp', ...dimensions }
+  }
+
+  return null
+}
+
+function parseAvif(bytes: Uint8Array): ParsedUploadImage | null {
+  if (!hasAscii(bytes, 4, 'ftyp')) {
+    return null
+  }
+  const isAvif = hasAscii(bytes, 8, 'avif') || hasAscii(bytes, 8, 'avis')
+    || hasAscii(bytes, 16, 'avif') || hasAscii(bytes, 16, 'avis')
+  if (!isAvif) {
+    return null
+  }
+
+  for (let offset = 0; offset + 16 <= bytes.length; offset += 1) {
+    if (!hasAscii(bytes, offset, 'ispe')) {
+      continue
+    }
+    const dimensions = toDimensions(readU32BE(bytes, offset + 8), readU32BE(bytes, offset + 12))
+    return dimensions === null ? null : { mime: 'image/avif', ...dimensions }
+  }
+
+  return null
+}
+
+function normalizeDeclaredMime(mime: string): UploadImageMime | null {
+  switch (mime.trim().toLowerCase()) {
+    case 'image/apng':
+    case 'image/png':
+      return 'image/png'
+    case 'image/avif':
+    case 'image/bmp':
+    case 'image/gif':
+    case 'image/webp':
+      return mime.trim().toLowerCase() as UploadImageMime
+    case 'image/jpe':
+    case 'image/jpg':
+    case 'image/jpeg':
+      return 'image/jpeg'
+    default:
+      return null
+  }
+}
+
+/**
+ * Parses a supported raster image's binary signature and intrinsic dimensions.
+ *
+ * @param bytes Complete image bytes.
+ * @returns Canonical MIME and dimensions, or `null` for unsupported/invalid content.
+ */
+export function parseUploadImage(bytes: Uint8Array): ParsedUploadImage | null {
+  return parsePng(bytes)
+    ?? parseGif(bytes)
+    ?? parseJpeg(bytes)
+    ?? parseWebp(bytes)
+    ?? parseBmp(bytes)
+    ?? parseAvif(bytes)
+}
+
+/**
+ * Validates an upload at the server boundary and derives trusted image metadata.
+ *
+ * The declared browser MIME type is checked when present, but the persisted MIME
+ * and dimensions always come from the binary image data.
+ *
+ * @param file Uploaded file from `FormData`.
+ * @returns Validated bytes and canonical metadata safe to persist.
+ * @throws When the file is too large, unsupported, malformed, or MIME-mismatched.
+ */
+export async function validateUploadImage(file: File): Promise<ValidatedUploadImage> {
+  if (file.size < 1) {
+    throw new Error('Image file is empty')
+  }
+  if (file.size > MAX_UPLOAD_SIZE_BYTES) {
+    throw new Error('Image size exceeds 10 MiB')
+  }
+
+  const bytes = await file.arrayBuffer()
+  const parsed = parseUploadImage(new Uint8Array(bytes))
+  if (parsed === null) {
+    throw new Error('Unsupported or malformed image content')
+  }
+
+  const declaredMime = file.type.length > 0 ? normalizeDeclaredMime(file.type) : parsed.mime
+  if (declaredMime === null || declaredMime !== parsed.mime) {
+    throw new Error('Image MIME type does not match its binary content')
+  }
+
+  return {
+    bytes,
+    ...parsed,
+  }
+}

--- a/src/lib/img/constants.ts
+++ b/src/lib/img/constants.ts
@@ -1,7 +1,16 @@
-/** Maximum accepted upload size in bytes (10 MB). */
-export const MAX_SIZE_LIMIT = import.meta.env.VITE_MAX_SIZE_LIMIT !== undefined
-  ? parseInt(String(import.meta.env.VITE_MAX_SIZE_LIMIT))
-  : 10 * 1024 * 1024
+import { MAX_UPLOAD_SIZE_BYTES } from '@/lib/images/uploadValidation'
+
+const configuredMaxSize = Number(import.meta.env.VITE_MAX_SIZE_LIMIT)
+
+/**
+ * Client-side upload limit in bytes.
+ *
+ * A deployment may choose a lower Vite value, but it may never advertise a
+ * limit above the server's enforced 10 MiB boundary.
+ */
+export const MAX_SIZE_LIMIT = Number.isFinite(configuredMaxSize) && configuredMaxSize > 0
+  ? Math.min(configuredMaxSize, MAX_UPLOAD_SIZE_BYTES)
+  : MAX_UPLOAD_SIZE_BYTES
 
 /** MIME types accepted for input images. */
 export const SUPPORTED_FORMAT_MIME_TYPES = [
@@ -12,7 +21,6 @@ export const SUPPORTED_FORMAT_MIME_TYPES = [
   'image/jpg',
   'image/jpeg',
   'image/png',
-  'image/svg+xml',
   'image/webp',
   'image/bmp',
 ]

--- a/src/lib/storage/albumsRepo.ts
+++ b/src/lib/storage/albumsRepo.ts
@@ -1,5 +1,5 @@
 import type { AlbumRecord, StorageBootstrapResult, StorageMeta } from '@/lib/storage/types'
-import { eq, sql } from 'drizzle-orm'
+import { eq, isNull, sql } from 'drizzle-orm'
 import { nanoid } from 'nanoid'
 import { getDb } from '@/lib/db/client'
 import { albumsTable, imagesTable } from '@/lib/db/schema'
@@ -28,6 +28,7 @@ async function loadAlbumUsageById(): Promise<Map<string, { imageCount: number, b
       bytesUsed: sql<number>`COALESCE(SUM(${imagesTable.bytes}), 0)`,
     })
     .from(imagesTable)
+    .where(isNull(imagesTable.deletedAt))
     .groupBy(imagesTable.albumId)
 
   const usageById = new Map<string, { imageCount: number, bytesUsed: number }>()
@@ -151,6 +152,7 @@ async function buildStorageMetaInternal(): Promise<StorageMeta> {
       maxUpdatedAt: sql<number>`COALESCE(MAX(${imagesTable.updatedAt}), 0)`,
     })
     .from(imagesTable)
+    .where(isNull(imagesTable.deletedAt))
 
   const updatedAtMs = Math.max(
     albumTotals?.maxUpdatedAt ?? 0,

--- a/src/lib/storage/imageCleanup.test.ts
+++ b/src/lib/storage/imageCleanup.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { deleteImageSafely, reconcilePendingImageDeletes } from './imageCleanup'
+
+const mocks = vi.hoisted(() => ({
+  deleteImageObject: vi.fn(),
+  deleteImageRecords: vi.fn(),
+  listImagesPendingDeletion: vi.fn(),
+  markImageForDeletion: vi.fn(),
+  recordImageCleanupFailure: vi.fn(),
+}))
+
+vi.mock('@/lib/storage/imagesRepo', () => ({
+  deleteImageRecords: mocks.deleteImageRecords,
+  listImagesPendingDeletion: mocks.listImagesPendingDeletion,
+  markImageForDeletion: mocks.markImageForDeletion,
+  recordImageCleanupFailure: mocks.recordImageCleanupFailure,
+}))
+
+vi.mock('@/lib/storage/r2Repo', () => ({
+  deleteImageObject: mocks.deleteImageObject,
+}))
+
+const image = {
+  objectKey: '2026/07/15/image.webp',
+  albumId: 'album-1',
+  name: 'image',
+  originalName: 'image.webp',
+  storedName: 'image.webp',
+  ext: 'webp',
+  mime: 'image/webp',
+  sizeBytes: 100,
+  width: 10,
+  height: 10,
+  createdAt: '2026-07-15T00:00:00.000Z',
+  updatedAt: '2026-07-15T00:00:00.000Z',
+  source: 'dashboard-upload' as const,
+}
+
+const bindings = {
+  db: {} as D1Database,
+  r2: {} as R2Bucket,
+}
+
+describe('imageCleanup', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('tombstones before deleting the matching R2 object', async () => {
+    await expect(deleteImageSafely({ ...bindings, image })).resolves.toEqual({
+      image,
+      cleanupPending: false,
+    })
+
+    expect(mocks.markImageForDeletion).toHaveBeenCalledWith(bindings.db, image.objectKey)
+    expect(mocks.deleteImageObject).toHaveBeenCalledWith(bindings.r2, image.objectKey)
+    expect(mocks.deleteImageRecords).toHaveBeenCalledWith(bindings.db, image)
+    expect(mocks.recordImageCleanupFailure).not.toHaveBeenCalled()
+  })
+
+  it('retains a tombstone when R2 cleanup fails', async () => {
+    mocks.deleteImageObject.mockRejectedValueOnce(new Error('R2 unavailable'))
+
+    await expect(deleteImageSafely({ ...bindings, image })).resolves.toEqual({
+      image,
+      cleanupPending: true,
+    })
+
+    expect(mocks.deleteImageRecords).not.toHaveBeenCalled()
+    expect(mocks.recordImageCleanupFailure).toHaveBeenCalledWith(bindings.db, {
+      objectKey: image.objectKey,
+      message: 'R2 unavailable',
+    })
+  })
+
+  it('retries each pending tombstone and leaves failed ones for later', async () => {
+    const failedImage = { ...image, objectKey: '2026/07/15/failed.webp' }
+    mocks.listImagesPendingDeletion.mockResolvedValueOnce([image, failedImage])
+    mocks.deleteImageObject
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('transient failure'))
+
+    await expect(reconcilePendingImageDeletes({ ...bindings, limit: 2 })).resolves.toEqual({
+      reconciled: 1,
+      pending: 1,
+    })
+
+    expect(mocks.deleteImageRecords).toHaveBeenCalledTimes(1)
+    expect(mocks.deleteImageRecords).toHaveBeenCalledWith(bindings.db, image)
+    expect(mocks.recordImageCleanupFailure).toHaveBeenCalledWith(bindings.db, {
+      objectKey: failedImage.objectKey,
+      message: 'transient failure',
+    })
+  })
+})

--- a/src/lib/storage/imageCleanup.ts
+++ b/src/lib/storage/imageCleanup.ts
@@ -1,0 +1,88 @@
+import type { ImageRecord } from '@/lib/storage/types'
+import {
+  deleteImageRecords,
+  listImagesPendingDeletion,
+  markImageForDeletion,
+  recordImageCleanupFailure,
+} from '@/lib/storage/imagesRepo'
+import { deleteImageObject } from '@/lib/storage/r2Repo'
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export interface ImageDeleteResult {
+  image: ImageRecord
+  cleanupPending: boolean
+}
+
+/**
+ * Makes an image unavailable immediately, then deletes its R2 object.
+ *
+ * If either R2 deletion or final metadata removal fails, the tombstoned image
+ * remains hidden and is retried by `reconcilePendingImageDeletes`.
+ *
+ * @param input D1/R2 bindings and the canonical image record.
+ * @param input.db D1 metadata binding.
+ * @param input.r2 R2 object binding.
+ * @param input.image Canonical image metadata being deleted.
+ * @returns Whether a later reconciliation attempt is required.
+ */
+export async function deleteImageSafely(input: {
+  db: D1Database
+  r2: R2Bucket
+  image: ImageRecord
+}): Promise<ImageDeleteResult> {
+  const { db, r2, image } = input
+  await markImageForDeletion(db, image.objectKey)
+
+  try {
+    await deleteImageObject(r2, image.objectKey)
+    await deleteImageRecords(db, image)
+    return { image, cleanupPending: false }
+  }
+  catch (error) {
+    await recordImageCleanupFailure(db, {
+      objectKey: image.objectKey,
+      message: errorMessage(error),
+    })
+    return { image, cleanupPending: true }
+  }
+}
+
+/**
+ * Retries a bounded number of tombstoned image deletions.
+ *
+ * @param input D1/R2 bindings and retry limit.
+ * @param input.db D1 metadata binding.
+ * @param input.r2 R2 object binding.
+ * @param input.limit Maximum tombstones to attempt in one run.
+ * @returns Counts suitable for observability without exposing object keys.
+ */
+export async function reconcilePendingImageDeletes(input: {
+  db: D1Database
+  r2: R2Bucket
+  limit?: number
+}): Promise<{ reconciled: number, pending: number }> {
+  const pendingImages = await listImagesPendingDeletion(input.db, input.limit ?? 10)
+  let reconciled = 0
+
+  for (const image of pendingImages) {
+    try {
+      await deleteImageObject(input.r2, image.objectKey)
+      await deleteImageRecords(input.db, image)
+      reconciled += 1
+    }
+    catch (error) {
+      await recordImageCleanupFailure(input.db, {
+        objectKey: image.objectKey,
+        message: errorMessage(error),
+      })
+    }
+  }
+
+  return {
+    reconciled,
+    pending: pendingImages.length - reconciled,
+  }
+}

--- a/src/lib/storage/imagesRepo.ts
+++ b/src/lib/storage/imagesRepo.ts
@@ -6,7 +6,7 @@ import type {
   ListAlbumImagesInput,
   ListAlbumImagesResult,
 } from '@/lib/storage/types'
-import { and, desc, eq, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, isNotNull, isNull, sql } from 'drizzle-orm'
 import { getDb } from '@/lib/db/client'
 import { decodeImageListCursor, encodeImageListCursor } from '@/lib/db/cursor'
 import { imagesTable } from '@/lib/db/schema'
@@ -118,7 +118,7 @@ export async function getImageRecord(_db: D1Database, objectKey: string): Promis
       source: imagesTable.source,
     })
     .from(imagesTable)
-    .where(eq(imagesTable.id, objectKey))
+    .where(and(eq(imagesTable.id, objectKey), isNull(imagesTable.deletedAt)))
     .limit(1)
 
   return row === undefined ? null : toImageRecord(row)
@@ -170,6 +170,9 @@ export async function putImageRecords(
         storedName: image.storedName,
         mime: image.mime,
         source: image.source,
+        deletedAt: null,
+        cleanupAttempts: 0,
+        cleanupError: null,
       },
     })
 }
@@ -190,7 +193,10 @@ export async function listAlbumImages(
     ? decodeImageListCursor(input.cursor)
     : null
 
-  const conditions: SQL[] = [eq(imagesTable.albumId, input.albumId)]
+  const conditions: SQL[] = [
+    eq(imagesTable.albumId, input.albumId),
+    isNull(imagesTable.deletedAt),
+  ]
   if (needle.length > 0) {
     conditions.push(sql`instr(${imagesTable.nameLower}, ${needle}) > 0`)
   }
@@ -246,6 +252,87 @@ export async function listAlbumImages(
 export async function deleteImageRecords(_db: D1Database, image: ImageRecord): Promise<void> {
   const db = getDb()
   await db.delete(imagesTable).where(eq(imagesTable.id, image.objectKey))
+}
+
+/**
+ * Hides an image before its R2 binary is deleted.
+ *
+ * The retained tombstone is the reconciliation record if R2 cleanup fails.
+ *
+ * @param _db D1 binding.
+ * @param objectKey Canonical image object key.
+ */
+export async function markImageForDeletion(_db: D1Database, objectKey: string): Promise<void> {
+  const db = getDb()
+  await db
+    .update(imagesTable)
+    .set({
+      deletedAt: Date.now(),
+      cleanupError: null,
+    })
+    .where(and(eq(imagesTable.id, objectKey), isNull(imagesTable.deletedAt)))
+}
+
+/**
+ * Records an R2 cleanup failure against an already-hidden image tombstone.
+ *
+ * @param _db D1 binding.
+ * @param input Cleanup-failure details.
+ * @param input.objectKey Canonical image object key.
+ * @param input.message Error details retained for the next reconciliation attempt.
+ */
+export async function recordImageCleanupFailure(
+  _db: D1Database,
+  input: { objectKey: string, message: string },
+): Promise<void> {
+  const db = getDb()
+  await db
+    .update(imagesTable)
+    .set({
+      cleanupAttempts: sql`${imagesTable.cleanupAttempts} + 1`,
+      cleanupError: input.message.slice(0, 500),
+    })
+    .where(and(eq(imagesTable.id, input.objectKey), isNotNull(imagesTable.deletedAt)))
+}
+
+/**
+ * Lists hidden records whose R2 object deletion needs another attempt.
+ *
+ * @param _db D1 binding.
+ * @param limit Maximum tombstones to process.
+ * @returns Oldest pending image records first.
+ */
+export async function listImagesPendingDeletion(
+  _db: D1Database,
+  limit: number,
+): Promise<ImageRecord[]> {
+  const db = getDb()
+  const rows = await db
+    .select({
+      id: imagesTable.id,
+      albumId: imagesTable.albumId,
+      name: imagesTable.name,
+      nameLower: imagesTable.nameLower,
+      ext: imagesTable.ext,
+      bytes: imagesTable.bytes,
+      width: imagesTable.width,
+      height: imagesTable.height,
+      createdAt: imagesTable.createdAt,
+      updatedAt: imagesTable.updatedAt,
+      originalName: imagesTable.originalName,
+      storedName: imagesTable.storedName,
+      mime: imagesTable.mime,
+      source: imagesTable.source,
+      deletedAt: imagesTable.deletedAt,
+      cleanupAttempts: imagesTable.cleanupAttempts,
+      cleanupError: imagesTable.cleanupError,
+    })
+    .from(imagesTable)
+    .where(isNotNull(imagesTable.deletedAt))
+    .orderBy(asc(imagesTable.deletedAt), asc(imagesTable.id))
+    .limit(Math.max(1, Math.min(100, Math.trunc(limit))))
+
+  return (rows as ImageRow[]).map(toImageRecord)
 }
 
 /**


### PR DESCRIPTION
## Description

Make image deletion recoverable when R2 cleanup fails, and validate uploaded image bytes at the server trust boundary.

## Feature changes

- Tombstone image metadata before R2 deletion, hide it from usage/listing results, and retry pending cleanup during subsequent listings.
- Validate file size, binary signature, MIME, and intrinsic dimensions server-side; no longer trust client-submitted dimensions.
- Keep a configured client upload limit when lower than the server cap, while clamping it to the enforced 10 MiB maximum.

## Bug fixes

- Validate canonical metadata before deleting an R2 object, preventing an arbitrary requested key from being deleted.
- Keep failed cleanup work discoverable instead of leaving inconsistent visible metadata.

## Migration

Apply `migrations/0002_image_cleanup_tombstones.sql` with the normal migration workflow before deploying this code.

## Testing

- `pnpm test`
- `pnpm exec tsc --noEmit`
- Targeted ESLint on changed TypeScript files
- `pnpm run build`

## Review checklist

- [x] No new dependencies
- [x] Server boundary tests cover invalid binary metadata and recovery paths
- [x] Storage listing and usage queries exclude tombstones