### PR TITLE
feat(dashboard): recover partial upload batches

### DIFF
--- a/src/features/dashboard/components/DashboardFeature.tsx
+++ b/src/features/dashboard/components/DashboardFeature.tsx
@@ -1,5 +1,5 @@
 import { ImageIcon } from 'lucide-react'
-import { useMemo, useRef, useState, useTransition } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Spinner } from '@/components/ui/spinner'
@@ -24,7 +24,6 @@ const DEFAULT_TOTAL_SPACE_BYTES = 5 * 1024 * 1024 * 1024
  * Stateful dashboard feature that wires albums, images, and mutation dialogs.
  */
 export function DashboardFeature() {
-  const [isUploadPending, startUploadTransition] = useTransition()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   const [renameAlbumId, setRenameAlbumId] = useState<string | null>(null)
@@ -48,6 +47,8 @@ export function DashboardFeature() {
     imagesStatus,
     imageUrlError,
     isUploading,
+    uploadProgress,
+    failedUploadCount,
     meta,
     mobileSidebarOpen,
     pageIndex,
@@ -73,6 +74,7 @@ export function DashboardFeature() {
     setPendingDeleteObjectKey,
     selectAlbum,
     uploadFiles,
+    retryFailedUploads,
   } = useDashboardData()
 
   const selectedAlbum = albumById.get(selectedAlbumId)
@@ -171,19 +173,16 @@ export function DashboardFeature() {
             fileInputRef={fileInputRef}
             onUploadClick={() => fileInputRef.current?.click()}
             onUploadChange={(files) => {
-              startUploadTransition(async () => {
-                try {
-                  await uploadFiles(files)
-                }
-                finally {
-                  if (fileInputRef.current) {
-                    fileInputRef.current.value = ''
-                  }
-                }
-              })
+              void uploadFiles(files)
+              if (fileInputRef.current) {
+                fileInputRef.current.value = ''
+              }
             }}
-            uploadDisabled={isUploading || isUploadPending || !selectedAlbumId}
-            uploadLoading={isUploading || isUploadPending}
+            uploadDisabled={isUploading || !selectedAlbumId}
+            uploadLoading={isUploading}
+            uploadProgress={uploadProgress}
+            failedUploadCount={failedUploadCount}
+            onRetryFailedUploads={() => void retryFailedUploads()}
             bulkOptions={(
               <BulkOptionsMenu
                 selectedImages={selectedImagesOrdered}

--- a/src/features/dashboard/components/DashboardTopbar.tsx
+++ b/src/features/dashboard/components/DashboardTopbar.tsx
@@ -1,7 +1,10 @@
 import type { ReactNode } from 'react'
+import type { UploadProgress } from '@/features/dashboard/hooks/useUpload'
 import { Search, Upload } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { LoadingButton } from '@/components/ui/loading-button'
+import { Progress } from '@/components/ui/progress'
 
 interface DashboardTopbarProps {
   search: string
@@ -10,6 +13,9 @@ interface DashboardTopbarProps {
   onUploadChange: (files: FileList | null) => void
   uploadDisabled: boolean
   uploadLoading: boolean
+  uploadProgress: UploadProgress | null
+  failedUploadCount: number
+  onRetryFailedUploads: () => void
   fileInputRef: React.RefObject<HTMLInputElement | null>
   bulkOptions: ReactNode
 }
@@ -21,38 +27,63 @@ export function DashboardTopbar({
   onUploadChange,
   uploadDisabled,
   uploadLoading,
+  uploadProgress,
+  failedUploadCount,
+  onRetryFailedUploads,
   fileInputRef,
   bulkOptions,
 }: DashboardTopbarProps) {
   return (
-    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-      <div className="relative flex-1">
-        <Search className="pointer-events-none absolute top-2.5 left-2 h-4 w-4 text-muted-foreground" />
-        <Input
-          className="pl-8"
-          placeholder="Search images..."
-          value={search}
-          onChange={event_ => onSearchChange(event_.target.value)}
+    <div className="space-y-2">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <div className="relative flex-1">
+          <Search className="pointer-events-none absolute top-2.5 left-2 h-4 w-4 text-muted-foreground" />
+          <Input
+            className="pl-8"
+            placeholder="Search images..."
+            value={search}
+            onChange={event_ => onSearchChange(event_.target.value)}
+          />
+        </div>
+        <LoadingButton
+          onClick={onUploadClick}
+          disabled={uploadDisabled}
+          loading={uploadLoading}
+          loadingText="Uploading..."
+        >
+          <Upload className="mr-2 h-4 w-4" />
+          Upload
+        </LoadingButton>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept="image/*"
+          className="hidden"
+          onChange={event_ => onUploadChange(event_.target.files)}
         />
+        {bulkOptions}
       </div>
-      <LoadingButton
-        onClick={onUploadClick}
-        disabled={uploadDisabled}
-        loading={uploadLoading}
-        loadingText="Uploading..."
-      >
-        <Upload className="mr-2 h-4 w-4" />
-        Upload
-      </LoadingButton>
-      <input
-        ref={fileInputRef}
-        type="file"
-        multiple
-        accept="image/*"
-        className="hidden"
-        onChange={event_ => onUploadChange(event_.target.files)}
-      />
-      {bulkOptions}
+      {uploadProgress !== null && (
+        <div className="rounded-md border bg-muted/40 px-3 py-2" role="status" aria-live="polite">
+          <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
+            <span>
+              {uploadLoading
+                ? `Uploading ${uploadProgress.completed} of ${uploadProgress.total}`
+                : `Uploaded ${uploadProgress.succeeded} of ${uploadProgress.total}`}
+              {uploadProgress.failed > 0 && ` · ${uploadProgress.failed} failed`}
+            </span>
+            {failedUploadCount > 0 && !uploadLoading && (
+              <Button type="button" size="sm" variant="outline" onClick={onRetryFailedUploads}>
+                Retry failed (
+                {failedUploadCount}
+                )
+              </Button>
+            )}
+          </div>
+          <Progress className="mt-2" value={(uploadProgress.completed / uploadProgress.total) * 100} />
+        </div>
+      )}
     </div>
   )
 }

--- a/src/features/dashboard/hooks/useDashboardData.ts
+++ b/src/features/dashboard/hooks/useDashboardData.ts
@@ -286,7 +286,13 @@ export function useDashboardData() {
     }))
   }, [])
 
-  const { isUploading, uploadFiles } = useUpload({
+  const {
+    isUploading,
+    uploadProgress,
+    failedUploadCount,
+    uploadFiles,
+    retryFailedUploads,
+  } = useUpload({
     selectedAlbumId,
     onUploaded: (uploaded) => {
       const uploadViewKey = currentViewKey
@@ -635,7 +641,10 @@ export function useDashboardData() {
     pendingDeleteObjectKey,
     setPendingDeleteObjectKey,
     isUploading,
+    uploadProgress,
+    failedUploadCount,
     uploadFiles,
+    retryFailedUploads,
     createAlbum,
     renameAlbum,
     moveAlbum,

--- a/src/features/dashboard/hooks/useUpload.ts
+++ b/src/features/dashboard/hooks/useUpload.ts
@@ -1,8 +1,9 @@
 import type { AlbumImageRecord, ImageRecord } from '@/lib/storage/types'
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { uploadImageFn } from '@/functions/images'
-import { getImageDimensions } from '@/lib/images/dimensions'
+
+const UPLOAD_CONCURRENCY = 3
 
 interface UseUploadOptions {
   selectedAlbumId: string
@@ -13,6 +14,23 @@ export interface UploadedImage {
   image: ImageRecord
   albumImage: AlbumImageRecord
   publicUrl: string | null
+}
+
+interface FailedUpload {
+  file: File
+  message: string
+  albumId: string
+}
+
+export interface UploadProgress {
+  total: number
+  completed: number
+  succeeded: number
+  failed: number
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }
 
 /**
@@ -26,54 +44,106 @@ export interface UploadedImage {
 export function useUpload(options: UseUploadOptions) {
   const { selectedAlbumId, onUploaded } = options
   const [isUploading, setIsUploading] = useState(false)
+  const [uploadProgress, setUploadProgress] = useState<UploadProgress | null>(null)
+  const [failedUploads, setFailedUploads] = useState<FailedUpload[]>([])
+  const uploadLockRef = useRef(false)
 
-  const uploadFiles = useCallback(async (files: FileList | null) => {
-    if (!files || files.length === 0) {
+  const uploadFiles = useCallback(async (
+    files: FileList | readonly File[] | null,
+    targetAlbumId = selectedAlbumId,
+  ) => {
+    const batch = files === null ? [] : Array.from(files)
+    if (batch.length === 0) {
       return
     }
 
-    if (!selectedAlbumId) {
+    if (uploadLockRef.current) {
+      return
+    }
+
+    if (!targetAlbumId) {
       toast.error('Select an album first')
       return
     }
 
+    uploadLockRef.current = true
     setIsUploading(true)
-    try {
-      const uploaded: UploadedImage[] = []
-      for (const file of Array.from(files)) {
-        const dimensions = await getImageDimensions(file)
-        if (dimensions === null) {
-          toast.warning('Could not read image dimensions', {
-            description: `Uploading ${file.name} without width/height metadata`,
+    setFailedUploads([])
+    setUploadProgress({
+      total: batch.length,
+      completed: 0,
+      succeeded: 0,
+      failed: 0,
+    })
+
+    const uploaded: UploadedImage[] = []
+    const failures: FailedUpload[] = []
+    let nextIndex = 0
+    let completed = 0
+
+    const uploadNext = async (): Promise<void> => {
+      while (nextIndex < batch.length) {
+        const file = batch[nextIndex]
+        nextIndex += 1
+
+        try {
+          const formData = new FormData()
+          formData.set('file', file)
+          formData.set('albumId', targetAlbumId)
+          formData.set('source', 'dashboard-upload')
+          uploaded.push(await uploadImageFn({ data: formData }))
+        }
+        catch (error) {
+          failures.push({ file, message: errorMessage(error), albumId: targetAlbumId })
+        }
+        finally {
+          completed += 1
+          setUploadProgress({
+            total: batch.length,
+            completed,
+            succeeded: uploaded.length,
+            failed: failures.length,
           })
         }
+      }
+    }
 
-        const formData = new FormData()
-        formData.set('file', file)
-        formData.set('albumId', selectedAlbumId)
-        formData.set('source', 'dashboard-upload')
-        if (dimensions !== null) {
-          formData.set('width', String(dimensions.width))
-          formData.set('height', String(dimensions.height))
-        }
-        uploaded.push(await uploadImageFn({ data: formData }))
+    try {
+      await Promise.all(Array.from({ length: Math.min(UPLOAD_CONCURRENCY, batch.length) }, uploadNext))
+      if (uploaded.length > 0) {
+        onUploaded(uploaded)
       }
 
-      onUploaded(uploaded)
-      toast.success(`${files.length} image(s) uploaded`)
-    }
-    catch (error) {
-      toast.error('Upload failed', {
-        description: error instanceof Error ? error.message : String(error),
+      if (failures.length === 0) {
+        setUploadProgress(null)
+        toast.success(`${uploaded.length} image(s) uploaded`)
+        return
+      }
+
+      setFailedUploads(failures)
+      toast.warning(`${uploaded.length} of ${batch.length} image(s) uploaded`, {
+        description: `${failures.length} failed. ${failures[0].message} Retry only the failed files.`,
       })
     }
     finally {
       setIsUploading(false)
+      uploadLockRef.current = false
     }
   }, [onUploaded, selectedAlbumId])
 
+  const retryFailedUploads = useCallback(async () => {
+    const targetAlbumId = failedUploads[0]?.albumId
+    if (targetAlbumId === undefined) {
+      return
+    }
+    await uploadFiles(failedUploads.map(({ file }) => file), targetAlbumId)
+  }, [failedUploads, uploadFiles])
+
   return {
     isUploading,
+    uploadProgress,
+    failedUploadCount: failedUploads.length,
     uploadFiles,
+    retryFailedUploads,
   }
 }


### PR DESCRIPTION
## Description

Make Dashboard multi-file uploads resilient to individual failures and give users concrete progress and retry feedback.

## Feature changes

- Upload up to three files concurrently while a synchronous lock prevents duplicate batches.
- Preserve successful uploads when other files fail.
- Show live completed/succeeded/failed progress and offer a targeted retry for only failed files.
- Keep failed retries pinned to the original target album even if the user changes the selected album.
- Remove the redundant client-side dimension read; the server upload boundary validates and derives metadata.

## Testing

- `pnpm test`
- `pnpm exec tsc --noEmit`
- Targeted ESLint on changed Dashboard files
- `pnpm run build`

## UI verification

- Static review verified disabled/loading state, live status announcement, failure summary, and retry action.
- Interactive browser verification was unavailable in this environment.

## Review checklist

- [x] No new dependencies
- [x] Partial success does not discard completed uploads
- [x] Retry cannot send a failed file to a newly selected album