### PR TITLE
feat(albums): migrate contents before deletion

### DIFF
--- a/src/features/dashboard/components/DashboardFeature.tsx
+++ b/src/features/dashboard/components/DashboardFeature.tsx
@@ -12,6 +12,7 @@ import { SidebarAlbums } from '@/features/dashboard/components/SidebarAlbums'
 import { UsageSummary } from '@/features/dashboard/components/UsageSummary'
 import { AlbumDialogs } from '@/features/dashboard/dialogs/AlbumDialogs'
 import { BulkMoveImagesDialog } from '@/features/dashboard/dialogs/BulkMoveImagesDialog'
+import { DeleteAlbumDialog } from '@/features/dashboard/dialogs/DeleteAlbumDialog'
 import { DeleteImageDialog } from '@/features/dashboard/dialogs/DeleteImageDialog'
 import { RenameImageDialog } from '@/features/dashboard/dialogs/RenameImageDialog'
 import { useDashboardData } from '@/features/dashboard/hooks/useDashboardData'
@@ -33,6 +34,7 @@ export function DashboardFeature() {
     albumById,
     createAlbum,
     deleteImage,
+    deleteAlbum,
     bulkDeleteImages,
     bulkMoveImages,
     goFirstPage,
@@ -61,6 +63,7 @@ export function DashboardFeature() {
     moveImageObjectKey,
     pendingDeleteObjectKey,
     renameAlbum,
+    pendingDeleteAlbumId,
     selectedAlbumId,
     totalCount,
     totalPages,
@@ -72,6 +75,7 @@ export function DashboardFeature() {
     setRenameImageObjectKey,
     setMoveImageObjectKey,
     setPendingDeleteObjectKey,
+    setPendingDeleteAlbumId,
     selectAlbum,
     uploadFiles,
     retryFailedUploads,
@@ -111,11 +115,12 @@ export function DashboardFeature() {
         onCreateAlbumClick={() => setCreateDialogOpen(true)}
         onRequestRename={setRenameAlbumId}
         onRequestMove={setMoveAlbumId}
+        onRequestDelete={setPendingDeleteAlbumId}
         onSetDefault={setDefaultAlbum}
       />
       <UsageSummary meta={meta} totalSpaceBytes={DEFAULT_TOTAL_SPACE_BYTES} />
     </div>
-  ), [albums, meta, selectedAlbumId, selectAlbum, setDefaultAlbum, setMobileSidebarOpen])
+  ), [albums, meta, selectedAlbumId, selectAlbum, setDefaultAlbum, setMobileSidebarOpen, setPendingDeleteAlbumId])
 
   return (
     <DashboardLayout
@@ -264,6 +269,13 @@ export function DashboardFeature() {
         objectKey={pendingDeleteObjectKey}
         onDelete={deleteImage}
         onCancel={() => setPendingDeleteObjectKey(null)}
+      />
+
+      <DeleteAlbumDialog
+        album={pendingDeleteAlbumId === null ? null : (albumById.get(pendingDeleteAlbumId) ?? null)}
+        albums={albums}
+        onDelete={deleteAlbum}
+        onCancel={() => setPendingDeleteAlbumId(null)}
       />
 
       <AlbumDialogs

--- a/src/features/dashboard/components/SidebarAlbums.tsx
+++ b/src/features/dashboard/components/SidebarAlbums.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react'
 import type { AlbumRecord } from '@/lib/storage/types'
-import { FolderTree, Loader2, MoreHorizontal, MoveRight, PencilLine, Plus, Star } from 'lucide-react'
+import { FolderTree, Loader2, MoreHorizontal, MoveRight, PencilLine, Plus, Star, Trash2 } from 'lucide-react'
 import { useState, useTransition } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -18,6 +18,7 @@ interface SidebarAlbumsProps {
   onCreateAlbumClick: () => void
   onRequestRename: (albumId: string) => void
   onRequestMove: (albumId: string) => void
+  onRequestDelete: (albumId: string) => void
   onSetDefault: (albumId: string) => Promise<void>
 }
 
@@ -36,6 +37,7 @@ export function SidebarAlbums({
   onCreateAlbumClick,
   onRequestRename,
   onRequestMove,
+  onRequestDelete,
   onSetDefault,
 }: SidebarAlbumsProps) {
   const [isSettingDefaultPending, startSetDefaultTransition] = useTransition()
@@ -116,6 +118,12 @@ export function SidebarAlbums({
                       Move
                     </DropdownMenuItem>
                   )}
+                  {album.id !== ROOT_ALBUM_ID && (
+                    <DropdownMenuItem variant="destructive" onClick={() => onRequestDelete(album.id)} disabled={isSettingDefaultPending}>
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      Delete
+                    </DropdownMenuItem>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
@@ -137,6 +145,12 @@ export function SidebarAlbums({
               <ContextMenuItem onClick={() => onRequestMove(album.id)} disabled={isSettingDefaultPending}>
                 <MoveRight className="mr-2 h-4 w-4" />
                 Move
+              </ContextMenuItem>
+            )}
+            {album.id !== ROOT_ALBUM_ID && (
+              <ContextMenuItem variant="destructive" onClick={() => onRequestDelete(album.id)} disabled={isSettingDefaultPending}>
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete
               </ContextMenuItem>
             )}
           </ContextMenuContent>

--- a/src/features/dashboard/dialogs/DeleteAlbumDialog.tsx
+++ b/src/features/dashboard/dialogs/DeleteAlbumDialog.tsx
@@ -1,0 +1,76 @@
+import type { AlbumRecord } from '@/lib/storage/types'
+import { AlertTriangle } from 'lucide-react'
+import { useEffect, useState, useTransition } from 'react'
+import { toast } from 'sonner'
+import { AlertDialog, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogMedia, AlertDialogTitle } from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { LoadingButton } from '@/components/ui/loading-button'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { ROOT_ALBUM_ID } from '@/lib/storage/types'
+
+interface DeleteAlbumDialogProps {
+  album: AlbumRecord | null
+  albums: AlbumRecord[]
+  onDelete: (input: { albumId: string, targetAlbumId: string }) => Promise<void>
+  onCancel: () => void
+}
+
+function displayAlbumName(album: AlbumRecord): string {
+  return album.id === ROOT_ALBUM_ID ? 'Default' : album.name
+}
+
+/** Confirms album deletion after selecting where its contents will be migrated. */
+export function DeleteAlbumDialog({ album, albums, onDelete, onCancel }: DeleteAlbumDialogProps) {
+  const [isTransitionPending, startTransition] = useTransition()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [targetAlbumId, setTargetAlbumId] = useState<string>(ROOT_ALBUM_ID)
+  const isPending = isTransitionPending || isSubmitting
+
+  useEffect(() => {
+    if (album !== null) {
+      setTargetAlbumId(album.parentId ?? ROOT_ALBUM_ID)
+    }
+  }, [album])
+
+  const handleConfirm = () => {
+    if (album === null || isSubmitting) {
+      return
+    }
+    setIsSubmitting(true)
+    startTransition(() => {
+      onDelete({ albumId: album.id, targetAlbumId })
+        .catch(error => toast.error('Failed to delete album', { description: error instanceof Error ? error.message : String(error) }))
+        .finally(() => setIsSubmitting(false))
+    })
+  }
+
+  return (
+    <AlertDialog open={album !== null} onOpenChange={open => !open && !isPending && onCancel()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogMedia><AlertTriangle /></AlertDialogMedia>
+          <AlertDialogTitle>Delete album</AlertDialogTitle>
+          <AlertDialogDescription>
+            Images and child albums will move to the selected destination. Image files are not deleted.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="space-y-2">
+          <Label htmlFor="delete-album-target">Move contents to</Label>
+          <Select value={targetAlbumId} onValueChange={setTargetAlbumId} disabled={isPending}>
+            <SelectTrigger id="delete-album-target"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {albums.filter(item => item.id !== album?.id && !item.path.includes(album?.id ?? '')).map(item => (
+                <SelectItem key={item.id} value={item.id}>{displayAlbumName(item)}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <AlertDialogFooter>
+          <Button variant="outline" disabled={isPending} onClick={onCancel}>Cancel</Button>
+          <LoadingButton variant="destructive" loading={isPending} loadingText="Deleting..." onClick={handleConfirm}>Delete album</LoadingButton>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/features/dashboard/hooks/useDashboardData.ts
+++ b/src/features/dashboard/hooks/useDashboardData.ts
@@ -11,7 +11,7 @@ import type { AlbumImageListItem, AlbumRecord, StorageMeta } from '@/lib/storage
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react'
 import { toast } from 'sonner'
 import { useUpload } from '@/features/dashboard/hooks/useUpload'
-import { createAlbumFn, listAlbumsFn, moveAlbumFn, renameAlbumFn, setDefaultAlbumFn } from '@/functions/albums'
+import { createAlbumFn, deleteAlbumFn, listAlbumsFn, moveAlbumFn, renameAlbumFn, setDefaultAlbumFn } from '@/functions/albums'
 import { deleteImageFn, deleteImagesFn, listImagesFn, moveImageFn, moveImagesFn, renameImageFn } from '@/functions/images'
 import { ROOT_ALBUM_ID } from '@/lib/storage/types'
 
@@ -50,6 +50,7 @@ export function useDashboardData() {
   const [imagesError, setImagesError] = useState<string | null>(null)
   const [isImagesFetching, setIsImagesFetching] = useState(false)
   const [pageIndex, setPageIndex] = useState(0)
+  const [imagesRevision, setImagesRevision] = useState(0)
   const [pageSize, setPageSize] = useState(DEFAULT_IMAGE_PAGE_SIZE)
   const [searchQuery, setSearchQuery] = useState('')
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('')
@@ -59,6 +60,7 @@ export function useDashboardData() {
   const [renameImageObjectKey, setRenameImageObjectKey] = useState<string | null>(null)
   const [moveImageObjectKey, setMoveImageObjectKey] = useState<string | null>(null)
   const [pendingDeleteObjectKey, setPendingDeleteObjectKey] = useState<string | null>(null)
+  const [pendingDeleteAlbumId, setPendingDeleteAlbumId] = useState<string | null>(null)
   const [isViewTransitionPending, startViewTransition] = useTransition()
   const imageRequestIdRef = useRef(0)
   const activeImagesRef = useRef(images)
@@ -68,7 +70,7 @@ export function useDashboardData() {
 
   const albumById = useMemo(() => new Map(albums.map(album => [album.id, album])), [albums])
   const selectedAlbum = albumById.get(selectedAlbumId) ?? null
-  const currentViewKey = `${selectedAlbumId}|${debouncedSearchQuery}`
+  const currentViewKey = `${selectedAlbumId}|${debouncedSearchQuery}|${imagesRevision}`
   const activeViewKeyRef = useRef(currentViewKey)
   const hasLoadedCurrentView = loadedViewKeys.has(currentViewKey)
   const hasLoadedAnyView = loadedViewKeys.size > 0
@@ -422,6 +424,22 @@ export function useDashboardData() {
     toast.success('Default album updated')
   }, [])
 
+  const deleteAlbum = useCallback(async (input: { albumId: string, targetAlbumId: string }) => {
+    const payload = await deleteAlbumFn({ data: input })
+    setAlbums(payload.albums)
+    setMeta(payload.meta)
+    imageRequestIdRef.current += 1
+    imageViewsRef.current.clear()
+    setLoadedViewKeys(new Set())
+    setImagesRevision(previous => previous + 1)
+    setPendingDeleteAlbumId(null)
+    if (selectedAlbumIdRef.current === payload.deletedAlbumId) {
+      setSelectedAlbumId(payload.targetAlbumId)
+      setPageIndex(0)
+    }
+    toast.success('Album deleted and contents moved')
+  }, [])
+
   const moveImage = useCallback(async ({ objectKey, targetAlbumId }: MoveImageInput) => {
     const viewKey = currentViewKey
     const sourceImage = images.find(image => image.objectKey === objectKey)
@@ -640,6 +658,8 @@ export function useDashboardData() {
     setMoveImageObjectKey,
     pendingDeleteObjectKey,
     setPendingDeleteObjectKey,
+    pendingDeleteAlbumId,
+    setPendingDeleteAlbumId,
     isUploading,
     uploadProgress,
     failedUploadCount,
@@ -654,6 +674,7 @@ export function useDashboardData() {
     bulkMoveImages,
     bulkDeleteImages,
     setDefaultAlbum,
+    deleteAlbum,
     searchQuery,
     onSearchQueryChange,
     pageIndex: pageIndex + 1,

--- a/src/functions/albums.ts
+++ b/src/functions/albums.ts
@@ -1,8 +1,8 @@
 import { createServerFn } from '@tanstack/react-start'
 import { requireAuth } from '@/lib/auth/guards'
 import { getD1Binding } from '@/lib/cloudflare/bindings'
-import { createAlbumRecord, ensureStorageBootstrap, listAlbumRecords, moveAlbumRecord, renameAlbumRecord, setDefaultAlbum } from '@/lib/storage/albumsRepo'
-import { createAlbumSchema, moveAlbumSchema, renameAlbumSchema, setDefaultAlbumSchema } from '@/lib/storage/validators'
+import { createAlbumRecord, deleteAlbumRecord, ensureStorageBootstrap, listAlbumRecords, moveAlbumRecord, renameAlbumRecord, setDefaultAlbum } from '@/lib/storage/albumsRepo'
+import { createAlbumSchema, deleteAlbumSchema, moveAlbumSchema, renameAlbumSchema, setDefaultAlbumSchema } from '@/lib/storage/validators'
 
 /**
  * Returns the full album tree and storage meta for dashboard/index use.
@@ -71,4 +71,16 @@ export const setDefaultAlbumFn = createServerFn({ method: 'POST' })
     const db = getD1Binding()
     const meta = await setDefaultAlbum(db, data)
     return { meta }
+  })
+
+/** Deletes an album after moving its direct contents and child albums to a destination. */
+export const deleteAlbumFn = createServerFn({ method: 'POST' })
+  .validator(deleteAlbumSchema)
+  .handler(async ({ data }) => {
+    await requireAuth()
+    const db = getD1Binding()
+    const result = await deleteAlbumRecord(db, data)
+    const albums = await listAlbumRecords(db)
+    const { meta } = await ensureStorageBootstrap(db)
+    return { ...result, albums, meta }
   })

--- a/src/lib/storage/albumsRepo.ts
+++ b/src/lib/storage/albumsRepo.ts
@@ -506,3 +506,68 @@ export async function moveAlbumRecord(
 
   return moved
 }
+
+/**
+ * Deletes a non-root album while preserving its images and children.
+ *
+ * Images in the deleted album and its direct child albums are moved to the
+ * supplied destination. A default upload destination is transferred first.
+ *
+ * @param _db D1 database binding.
+ * @param input Source and destination album ids.
+ * @param input.albumId Album to delete.
+ * @param input.targetAlbumId Album receiving the migrated contents.
+ * @returns The source and destination ids used by the migration.
+ * @throws When either album is missing, the source is root, or destination is a descendant.
+ */
+export async function deleteAlbumRecord(
+  _db: D1Database,
+  input: { albumId: string, targetAlbumId: string },
+): Promise<{ deletedAlbumId: string, targetAlbumId: string }> {
+  await ensureStorageBootstrap(_db)
+  if (input.albumId === ROOT_ALBUM_ID) {
+    throw new Error('Root album cannot be deleted')
+  }
+  if (input.albumId === input.targetAlbumId) {
+    throw new Error('Choose a different destination album')
+  }
+
+  const db = getDb()
+  const rows = await db
+    .select({ id: albumsTable.id, parentId: albumsTable.parentId, isDefault: albumsTable.isDefault })
+    .from(albumsTable)
+  const byId = new Map(rows.map(row => [row.id, row]))
+  const source = byId.get(input.albumId)
+  const target = byId.get(input.targetAlbumId)
+  if (source === undefined || target === undefined) {
+    throw new Error('Album not found')
+  }
+
+  let ancestorId: string | null = input.targetAlbumId
+  while (ancestorId !== null) {
+    if (ancestorId === input.albumId) {
+      throw new Error('Cannot migrate an album into one of its descendants')
+    }
+    ancestorId = byId.get(ancestorId)?.parentId ?? null
+  }
+
+  const timestamp = nowMs()
+  const moveImages = db.update(imagesTable).set({ albumId: input.targetAlbumId, updatedAt: timestamp }).where(eq(imagesTable.albumId, input.albumId))
+  const moveChildren = db.update(albumsTable).set({ parentId: input.targetAlbumId, updatedAt: timestamp }).where(eq(albumsTable.parentId, input.albumId))
+  const removeSource = db.delete(albumsTable).where(eq(albumsTable.id, input.albumId))
+  // D1 executes the batch atomically, so a failed foreign-key operation cannot leave a partial migration.
+  if (source.isDefault === 1) {
+    await db.batch([
+      db.update(albumsTable).set({ isDefault: 0, updatedAt: timestamp }).where(eq(albumsTable.id, input.albumId)),
+      db.update(albumsTable).set({ isDefault: 1, updatedAt: timestamp }).where(eq(albumsTable.id, input.targetAlbumId)),
+      moveImages,
+      moveChildren,
+      removeSource,
+    ])
+  }
+  else {
+    await db.batch([moveImages, moveChildren, removeSource])
+  }
+
+  return { deletedAlbumId: input.albumId, targetAlbumId: input.targetAlbumId }
+}

--- a/src/lib/storage/validators.ts
+++ b/src/lib/storage/validators.ts
@@ -38,6 +38,12 @@ export const setDefaultAlbumSchema = z.object({
   albumId: albumIdSchema,
 })
 
+/** Payload schema for deleting an album after migrating its contents. */
+export const deleteAlbumSchema = z.object({
+  albumId: albumIdSchema,
+  targetAlbumId: albumIdSchema,
+})
+
 /**
  * Payload schema for listing album images.
  */


### PR DESCRIPTION
## Description

Add a safe, explicit album deletion flow that migrates contents instead of deleting stored image files.

## Key changes

- Require a destination before deleting a non-root album.
- Atomically migrate direct images and child albums in D1 before removing the source.
- Transfer the default upload destination when deleting the default album.
- Prevent self/descendant targets and reload invalidated Dashboard image views.

## Testing

- `pnpm test`
- `pnpm exec tsc --noEmit`
- Targeted ESLint
- `pnpm run build`

## Review note

A focused audit identified and this PR fixes atomicity and stale-cache risks. Dedicated repository mock coverage for the D1 migration is a follow-up test-infrastructure gap; CI covers existing suite.