### PR TITLE
feat(images): reserve original asset variants

### DIFF
--- a/migrations/0003_image_original_variants.sql
+++ b/migrations/0003_image_original_variants.sql
@@ -1,0 +1,10 @@
+ALTER TABLE images ADD COLUMN original_object_key TEXT NULL;
+ALTER TABLE images ADD COLUMN original_bytes INTEGER NULL;
+ALTER TABLE images ADD COLUMN original_ext TEXT NULL;
+ALTER TABLE images ADD COLUMN original_mime TEXT NULL;
+ALTER TABLE images ADD COLUMN original_width INTEGER NULL;
+ALTER TABLE images ADD COLUMN original_height INTEGER NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_images_original_object_key
+  ON images(original_object_key)
+  WHERE original_object_key IS NOT NULL;

--- a/src/features/home/hooks/useImageTransformQueue.ts
+++ b/src/features/home/hooks/useImageTransformQueue.ts
@@ -112,7 +112,7 @@ export function useImageTransformQueue() {
   }, [])
 
   const transformOne = useCallback(async (item: HomeProcessedItem): Promise<HomeProcessedItem> => {
-    const { blob } = await transformImageFile(
+    const { blob, width, height } = await transformImageFile(
       item.originalFile,
       targetFormat,
       useManualQuality ? quality : undefined,
@@ -146,16 +146,14 @@ export function useImageTransformQueue() {
       }
     }
 
-    const dimensions = await getImageDimensions(compressedFile)
-
     return {
       ...item,
       targetFormat,
       outputBlob: blob,
       outputFile: compressedFile,
       outputSize: blob.size,
-      width: dimensions?.width ?? null,
-      height: dimensions?.height ?? null,
+      width,
+      height,
       status: 'compressed',
       transformError: null,
       uploadStatus: 'idle',

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,5 +1,5 @@
 import type { AnySQLiteColumn } from 'drizzle-orm/sqlite-core'
-import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { index, integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core'
 
 export const albumsTable = sqliteTable('albums', {
   id: text('id').primaryKey(),
@@ -38,11 +38,18 @@ export const imagesTable = sqliteTable('images', {
   deletedAt: integer('deleted_at'),
   cleanupAttempts: integer('cleanup_attempts').notNull().default(0),
   cleanupError: text('cleanup_error'),
+  originalObjectKey: text('original_object_key'),
+  originalBytes: integer('original_bytes'),
+  originalExt: text('original_ext'),
+  originalMime: text('original_mime'),
+  originalWidth: integer('original_width'),
+  originalHeight: integer('original_height'),
 }, table => [
   index('idx_images_album_created_desc').on(table.albumId, table.createdAt, table.id),
   index('idx_images_album_name_lower').on(table.albumId, table.nameLower),
   index('idx_images_created_desc').on(table.createdAt, table.id),
   index('idx_images_pending_cleanup').on(table.deletedAt, table.id),
+  uniqueIndex('ux_images_original_object_key').on(table.originalObjectKey),
 ])
 
 export type AlbumRow = typeof albumsTable.$inferSelect

--- a/src/lib/img/transform-client.ts
+++ b/src/lib/img/transform-client.ts
@@ -12,7 +12,7 @@ export async function transformImageFile(
   file: File,
   format: SupportedFormat,
   quality?: number,
-): Promise<{ blob: Blob, mimeType: string }> {
+): Promise<{ blob: Blob, mimeType: string, width: number, height: number }> {
   const bitmap = await createImageBitmap(file)
 
   try {
@@ -38,7 +38,7 @@ export async function transformImageFile(
       throw new Error(`Unable to encode image as ${format}`)
     }
 
-    return { blob, mimeType }
+    return { blob, mimeType, width: bitmap.width, height: bitmap.height }
   }
   finally {
     bitmap.close()

--- a/src/lib/storage/albumsRepo.ts
+++ b/src/lib/storage/albumsRepo.ts
@@ -25,7 +25,7 @@ async function loadAlbumUsageById(): Promise<Map<string, { imageCount: number, b
     .select({
       albumId: imagesTable.albumId,
       imageCount: sql<number>`CAST(COUNT(*) AS INTEGER)`,
-      bytesUsed: sql<number>`COALESCE(SUM(${imagesTable.bytes}), 0)`,
+      bytesUsed: sql<number>`COALESCE(SUM(${imagesTable.bytes} + COALESCE(${imagesTable.originalBytes}, 0)), 0)`,
     })
     .from(imagesTable)
     .where(isNull(imagesTable.deletedAt))
@@ -148,7 +148,7 @@ async function buildStorageMetaInternal(): Promise<StorageMeta> {
   const [imageTotals] = await db
     .select({
       totalImageCount: sql<number>`CAST(COUNT(*) AS INTEGER)`,
-      totalBytesUsed: sql<number>`COALESCE(SUM(${imagesTable.bytes}), 0)`,
+      totalBytesUsed: sql<number>`COALESCE(SUM(${imagesTable.bytes} + COALESCE(${imagesTable.originalBytes}, 0)), 0)`,
       maxUpdatedAt: sql<number>`COALESCE(MAX(${imagesTable.updatedAt}), 0)`,
     })
     .from(imagesTable)

--- a/src/lib/storage/imageCleanup.test.ts
+++ b/src/lib/storage/imageCleanup.test.ts
@@ -73,6 +73,25 @@ describe('imageCleanup', () => {
     })
   })
 
+  it('cleans a retained original after deleting its derived image', async () => {
+    const imageWithOriginal = {
+      ...image,
+      original: {
+        objectKey: 'originals/2026/07/15/image.png',
+        sizeBytes: 200,
+        ext: 'png',
+        mime: 'image/png',
+        width: 10,
+        height: 10,
+      },
+    }
+
+    await deleteImageSafely({ ...bindings, image: imageWithOriginal })
+
+    expect(mocks.deleteImageObject).toHaveBeenNthCalledWith(1, bindings.r2, image.objectKey)
+    expect(mocks.deleteImageObject).toHaveBeenNthCalledWith(2, bindings.r2, imageWithOriginal.original.objectKey)
+  })
+
   it('retries each pending tombstone and leaves failed ones for later', async () => {
     const failedImage = { ...image, objectKey: '2026/07/15/failed.webp' }
     mocks.listImagesPendingDeletion.mockResolvedValueOnce([image, failedImage])

--- a/src/lib/storage/imageCleanup.ts
+++ b/src/lib/storage/imageCleanup.ts
@@ -11,6 +11,13 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+async function deleteImageObjects(r2: R2Bucket, image: ImageRecord): Promise<void> {
+  await deleteImageObject(r2, image.objectKey)
+  if (image.original?.objectKey !== undefined) {
+    await deleteImageObject(r2, image.original.objectKey)
+  }
+}
+
 export interface ImageDeleteResult {
   image: ImageRecord
   cleanupPending: boolean
@@ -37,7 +44,7 @@ export async function deleteImageSafely(input: {
   await markImageForDeletion(db, image.objectKey)
 
   try {
-    await deleteImageObject(r2, image.objectKey)
+    await deleteImageObjects(r2, image)
     await deleteImageRecords(db, image)
     return { image, cleanupPending: false }
   }
@@ -69,7 +76,7 @@ export async function reconcilePendingImageDeletes(input: {
 
   for (const image of pendingImages) {
     try {
-      await deleteImageObject(input.r2, image.objectKey)
+      await deleteImageObjects(input.r2, image)
       await deleteImageRecords(input.db, image)
       reconciled += 1
     }

--- a/src/lib/storage/imagesRepo.ts
+++ b/src/lib/storage/imagesRepo.ts
@@ -61,9 +61,37 @@ interface ImageRow {
   storedName: string
   mime: string
   source: 'index-compressed' | 'dashboard-upload'
+  originalObjectKey?: string | null
+  originalBytes?: number | null
+  originalExt?: string | null
+  originalMime?: string | null
+  originalWidth?: number | null
+  originalHeight?: number | null
 }
 
 function toImageRecord(row: ImageRow): ImageRecord {
+  const originalValues = [row.originalBytes, row.originalExt, row.originalMime, row.originalWidth, row.originalHeight]
+  const hasOriginalMetadata = originalValues.some(value => value !== null && value !== undefined)
+  if (row.originalObjectKey === null || row.originalObjectKey === undefined) {
+    if (hasOriginalMetadata) {
+      throw new Error('Image original metadata is incomplete')
+    }
+  }
+  else if (
+    !row.originalObjectKey.startsWith('originals/')
+    || originalValues.some(value => value === null || value === undefined)
+    || (row.originalBytes ?? 0) < 1
+    || (row.originalWidth ?? 0) < 1
+    || (row.originalHeight ?? 0) < 1
+    || row.originalExt === null
+    || row.originalExt === undefined
+    || row.originalExt.length === 0
+    || row.originalMime === null
+    || row.originalMime === undefined
+    || row.originalMime.length === 0
+  ) {
+    throw new Error('Image original metadata is invalid')
+  }
   return {
     objectKey: row.id,
     albumId: row.albumId,
@@ -78,6 +106,34 @@ function toImageRecord(row: ImageRow): ImageRecord {
     createdAt: toIsoString(row.createdAt),
     updatedAt: toIsoString(row.updatedAt),
     source: row.source,
+    original: row.originalObjectKey === null || row.originalObjectKey === undefined
+      ? null
+      : {
+          objectKey: row.originalObjectKey,
+          sizeBytes: row.originalBytes ?? 0,
+          ext: row.originalExt ?? '',
+          mime: row.originalMime ?? '',
+          width: row.originalWidth ?? 0,
+          height: row.originalHeight ?? 0,
+        },
+  }
+}
+
+function validateOriginalAsset(image: ImageRecord): void {
+  const original = image.original
+  if (!original) {
+    return
+  }
+  if (
+    original.objectKey === image.objectKey
+    || !original.objectKey.startsWith('originals/')
+    || original.sizeBytes < 1
+    || original.width < 1
+    || original.height < 1
+    || !original.ext
+    || !original.mime
+  ) {
+    throw new Error('Invalid original image asset')
   }
 }
 
@@ -116,6 +172,12 @@ export async function getImageRecord(_db: D1Database, objectKey: string): Promis
       storedName: imagesTable.storedName,
       mime: imagesTable.mime,
       source: imagesTable.source,
+      originalObjectKey: imagesTable.originalObjectKey,
+      originalBytes: imagesTable.originalBytes,
+      originalExt: imagesTable.originalExt,
+      originalMime: imagesTable.originalMime,
+      originalWidth: imagesTable.originalWidth,
+      originalHeight: imagesTable.originalHeight,
     })
     .from(imagesTable)
     .where(and(eq(imagesTable.id, objectKey), isNull(imagesTable.deletedAt)))
@@ -132,6 +194,7 @@ export async function putImageRecords(
   image: ImageRecord,
   albumImage: AlbumImageRecord,
 ): Promise<void> {
+  validateOriginalAsset(image)
   const db = getDb()
   const createdAt = fromIsoString(image.createdAt)
   const updatedAt = fromIsoString(image.updatedAt)
@@ -153,6 +216,12 @@ export async function putImageRecords(
       storedName: image.storedName,
       mime: image.mime,
       source: image.source,
+      originalObjectKey: image.original?.objectKey ?? null,
+      originalBytes: image.original?.sizeBytes ?? null,
+      originalExt: image.original?.ext ?? null,
+      originalMime: image.original?.mime ?? null,
+      originalWidth: image.original?.width ?? null,
+      originalHeight: image.original?.height ?? null,
     })
     .onConflictDoUpdate({
       target: imagesTable.id,
@@ -170,6 +239,12 @@ export async function putImageRecords(
         storedName: image.storedName,
         mime: image.mime,
         source: image.source,
+        originalObjectKey: image.original?.objectKey ?? null,
+        originalBytes: image.original?.sizeBytes ?? null,
+        originalExt: image.original?.ext ?? null,
+        originalMime: image.original?.mime ?? null,
+        originalWidth: image.original?.width ?? null,
+        originalHeight: image.original?.height ?? null,
         deletedAt: null,
         cleanupAttempts: 0,
         cleanupError: null,
@@ -326,6 +401,12 @@ export async function listImagesPendingDeletion(
       deletedAt: imagesTable.deletedAt,
       cleanupAttempts: imagesTable.cleanupAttempts,
       cleanupError: imagesTable.cleanupError,
+      originalObjectKey: imagesTable.originalObjectKey,
+      originalBytes: imagesTable.originalBytes,
+      originalExt: imagesTable.originalExt,
+      originalMime: imagesTable.originalMime,
+      originalWidth: imagesTable.originalWidth,
+      originalHeight: imagesTable.originalHeight,
     })
     .from(imagesTable)
     .where(isNotNull(imagesTable.deletedAt))

--- a/src/lib/storage/r2Repo.ts
+++ b/src/lib/storage/r2Repo.ts
@@ -26,6 +26,11 @@ export function buildR2ObjectKey(input: { ext: string, date?: Date }): string {
   return `${year}/${month}/${day}/${objectId}.${ext}`
 }
 
+/** Builds an isolated key for an optional retained source asset. */
+export function buildOriginalR2ObjectKey(input: { ext: string, date?: Date }): string {
+  return `originals/${buildR2ObjectKey(input)}`
+}
+
 /**
  * Stores the final image object in R2 with content type and tracing metadata.
  *

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -47,6 +47,17 @@ export interface ImageRecord {
   createdAt: ISODateString
   updatedAt: ISODateString
   source: ImageSource
+  original?: OriginalImageAsset | null
+}
+
+/** Optional source asset retained beside a derived upload. */
+export interface OriginalImageAsset {
+  objectKey: string
+  sizeBytes: number
+  ext: string
+  mime: string
+  width: number
+  height: number
 }
 
 /**


### PR DESCRIPTION
## Description

Reserve a safe original-asset model without changing the default upload policy, and remove redundant image decoding from the compression pipeline.

## Key changes

- Add nullable original-asset metadata migration with isolated `originals/` key namespace.
- Require complete original metadata, count retained originals in usage, and clean them up with the derived image.
- Return dimensions from the already-decoded ImageBitmap, avoiding a second post-encode decode.

## Testing

- `pnpm test` (18 tests)
- `pnpm exec tsc --noEmit`
- Targeted ESLint
- `pnpm run build`

Original asset persistence remains opt-in infrastructure; no current UI flow stores originals by default.