### PR TITLE
fix(storage): enforce upload quota

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,6 +277,9 @@ Usage/accounting:
 
 - `totalBytesUsed`, `totalImageCount`, and related counters must be consistent with canonical data.
 - If using cached counters, provide a recount/reconcile path and document when it runs.
+- `storage_quota` is maintained only by D1 triggers. Reserve capacity before
+  uploading to R2, and retain that reservation until metadata is committed or
+  the orphaned object has been deleted; never update the counter directly.
 
 UI invariants:
 

--- a/migrations/0004_storage_quota.sql
+++ b/migrations/0004_storage_quota.sql
@@ -1,0 +1,108 @@
+CREATE TABLE IF NOT EXISTS storage_quota (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  bytes_used INTEGER NOT NULL CHECK (bytes_used >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS orphan_image_cleanup (
+  object_key TEXT PRIMARY KEY,
+  cleanup_attempts INTEGER NOT NULL DEFAULT 0,
+  cleanup_error TEXT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS storage_reservations (
+  object_key TEXT PRIMARY KEY,
+  bytes_reserved INTEGER NOT NULL CHECK (bytes_reserved > 0),
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_storage_reservations_created_at
+  ON storage_reservations(created_at ASC, object_key ASC);
+
+CREATE INDEX IF NOT EXISTS idx_orphan_image_cleanup_created_at
+  ON orphan_image_cleanup(created_at ASC, object_key ASC);
+
+INSERT OR IGNORE INTO storage_quota (id, bytes_used)
+SELECT 1, COALESCE(SUM(bytes + COALESCE(original_bytes, 0)), 0)
+FROM images
+;
+
+CREATE TRIGGER IF NOT EXISTS trg_images_quota_before_insert_original_bytes
+BEFORE INSERT ON images
+WHEN COALESCE(NEW.original_bytes, 0) < 0
+BEGIN
+  SELECT RAISE(ABORT, 'Original image bytes must be non-negative');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_images_quota_before_insert
+BEFORE INSERT ON images
+WHEN (SELECT bytes_used FROM storage_quota WHERE id = 1)
+  + NEW.bytes + COALESCE(NEW.original_bytes, 0)
+  - COALESCE((SELECT bytes_reserved FROM storage_reservations WHERE object_key = NEW.id), 0) > 5368709120
+BEGIN
+  SELECT RAISE(ABORT, 'Storage quota exceeded');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_images_quota_after_insert
+AFTER INSERT ON images
+BEGIN
+  UPDATE storage_quota
+  SET bytes_used = bytes_used + NEW.bytes + COALESCE(NEW.original_bytes, 0)
+  WHERE id = 1;
+  -- The temporary reservation has already been counted. Removing it after
+  -- adding the durable image bytes preserves the same total.
+  DELETE FROM storage_reservations WHERE object_key = NEW.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_images_quota_before_update
+BEFORE UPDATE OF bytes, original_bytes ON images
+WHEN COALESCE(NEW.original_bytes, 0) < 0
+BEGIN
+  SELECT RAISE(ABORT, 'Original image bytes must be non-negative');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_images_quota_before_update_limit
+BEFORE UPDATE OF bytes, original_bytes ON images
+WHEN (SELECT bytes_used FROM storage_quota WHERE id = 1)
+  + (NEW.bytes + COALESCE(NEW.original_bytes, 0))
+  - (OLD.bytes + COALESCE(OLD.original_bytes, 0)) > 5368709120
+BEGIN
+  SELECT RAISE(ABORT, 'Storage quota exceeded');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_images_quota_after_update
+AFTER UPDATE OF bytes, original_bytes ON images
+BEGIN
+  UPDATE storage_quota
+  SET bytes_used = bytes_used
+    + (NEW.bytes + COALESCE(NEW.original_bytes, 0))
+    - (OLD.bytes + COALESCE(OLD.original_bytes, 0))
+  WHERE id = 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_images_quota_after_delete
+AFTER DELETE ON images
+BEGIN
+  UPDATE storage_quota
+  SET bytes_used = MAX(0, bytes_used - OLD.bytes - COALESCE(OLD.original_bytes, 0))
+  WHERE id = 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_reservations_quota_before_insert
+BEFORE INSERT ON storage_reservations
+WHEN (SELECT bytes_used FROM storage_quota WHERE id = 1) + NEW.bytes_reserved > 5368709120
+BEGIN
+  SELECT RAISE(ABORT, 'Storage quota exceeded');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_reservations_quota_after_insert
+AFTER INSERT ON storage_reservations
+BEGIN
+  UPDATE storage_quota SET bytes_used = bytes_used + NEW.bytes_reserved WHERE id = 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_reservations_quota_after_delete
+AFTER DELETE ON storage_reservations
+BEGIN
+  UPDATE storage_quota SET bytes_used = MAX(0, bytes_used - OLD.bytes_reserved) WHERE id = 1;
+END;

--- a/src/features/dashboard/components/DashboardFeature.tsx
+++ b/src/features/dashboard/components/DashboardFeature.tsx
@@ -20,9 +20,8 @@ import { RenameImageDialog } from '@/features/dashboard/dialogs/RenameImageDialo
 import { useDashboardData } from '@/features/dashboard/hooks/useDashboardData'
 import { useImagesTable } from '@/features/dashboard/hooks/useImagesTable'
 import { formatBytes } from '@/lib/storage/format'
+import { STORAGE_QUOTA_BYTES } from '@/lib/storage/quota'
 import { Route } from '@/routes/dashboard'
-
-const DEFAULT_TOTAL_SPACE_BYTES = 5 * 1024 * 1024 * 1024
 
 /**
  * Stateful dashboard feature that wires albums, images, and mutation dialogs.
@@ -133,7 +132,7 @@ export function DashboardFeature() {
         onRequestDelete={setPendingDeleteAlbumId}
         onSetDefault={setDefaultAlbum}
       />
-      <UsageSummary meta={meta} totalSpaceBytes={DEFAULT_TOTAL_SPACE_BYTES} />
+      <UsageSummary meta={meta} totalSpaceBytes={STORAGE_QUOTA_BYTES} />
     </div>
   ), [albums, meta, selectedAlbumId, selectAlbum, setDefaultAlbum, setMobileSidebarOpen, setPendingDeleteAlbumId])
 

--- a/src/features/dashboard/hooks/useDashboardData.ts
+++ b/src/features/dashboard/hooks/useDashboardData.ts
@@ -280,7 +280,7 @@ export function useDashboardData(options: UseDashboardDataOptions) {
       for (const { albumImage } of uploaded) {
         const current = usage.get(albumImage.albumId) ?? { imageCount: 0, bytesUsed: 0 }
         current.imageCount += 1
-        current.bytesUsed += albumImage.sizeBytes
+        current.bytesUsed += albumImage.storageBytes
         usage.set(albumImage.albumId, current)
       }
       updateAlbumUsage(usage)
@@ -289,7 +289,7 @@ export function useDashboardData(options: UseDashboardDataOptions) {
         : {
             ...previous,
             totalImageCount: previous.totalImageCount + uploaded.length,
-            totalBytesUsed: previous.totalBytesUsed + uploaded.reduce((total, { albumImage }) => total + albumImage.sizeBytes, 0),
+            totalBytesUsed: previous.totalBytesUsed + uploaded.reduce((total, { albumImage }) => total + albumImage.storageBytes, 0),
             updatedAt: new Date().toISOString(),
           })
     },
@@ -424,8 +424,8 @@ export function useDashboardData(options: UseDashboardDataOptions) {
     refreshImages()
     if (sourceImage !== undefined && sourceImage.albumId !== targetAlbumId) {
       updateAlbumUsage(new Map([
-        [sourceImage.albumId, { imageCount: -1, bytesUsed: -sourceImage.sizeBytes }],
-        [targetAlbumId, { imageCount: 1, bytesUsed: sourceImage.sizeBytes }],
+        [sourceImage.albumId, { imageCount: -1, bytesUsed: -sourceImage.storageBytes }],
+        [targetAlbumId, { imageCount: 1, bytesUsed: sourceImage.storageBytes }],
       ]))
     }
     setMoveImageObjectKey(null)
@@ -449,14 +449,17 @@ export function useDashboardData(options: UseDashboardDataOptions) {
     refreshImages()
     updateAlbumUsage(new Map([[
       payload.image.albumId,
-      { imageCount: -1, bytesUsed: -payload.image.sizeBytes },
+      { imageCount: -1, bytesUsed: -(payload.image.sizeBytes + (payload.image.original?.sizeBytes ?? 0)) },
     ]]))
+    const storageBytes = payload.image.sizeBytes + (payload.image.original?.sizeBytes ?? 0)
     setMeta(previous => previous === null
       ? previous
       : {
           ...previous,
           totalImageCount: Math.max(0, previous.totalImageCount - 1),
-          totalBytesUsed: Math.max(0, previous.totalBytesUsed - payload.image.sizeBytes),
+          totalBytesUsed: payload.cleanupPending
+            ? previous.totalBytesUsed
+            : Math.max(0, previous.totalBytesUsed - storageBytes),
           updatedAt: new Date().toISOString(),
         })
     setPendingDeleteObjectKey(null)
@@ -480,7 +483,7 @@ export function useDashboardData(options: UseDashboardDataOptions) {
       refreshImages()
     }
     if (targetAlbumId !== selectedAlbumId && sourceImages.length > 0) {
-      const bytesUsed = sourceImages.reduce((total, image) => total + image.sizeBytes, 0)
+      const bytesUsed = sourceImages.reduce((total, image) => total + image.storageBytes, 0)
       updateAlbumUsage(new Map([
         [selectedAlbumId, { imageCount: -sourceImages.length, bytesUsed: -bytesUsed }],
         [targetAlbumId, { imageCount: sourceImages.length, bytesUsed }],
@@ -500,18 +503,20 @@ export function useDashboardData(options: UseDashboardDataOptions) {
     if (result.succeededObjectKeys.length > 0) {
       refreshImages()
     }
+    const cleanedImages = deletedImages.filter(image => !result.cleanupPendingObjectKeys.includes(image.objectKey))
     if (deletedImages.length > 0) {
-      const bytesUsed = deletedImages.reduce((total, image) => total + image.sizeBytes, 0)
+      const albumBytesUsed = deletedImages.reduce((total, image) => total + image.storageBytes, 0)
+      const releasedBytes = cleanedImages.reduce((total, image) => total + image.storageBytes, 0)
       updateAlbumUsage(new Map([[
         selectedAlbumId,
-        { imageCount: -deletedImages.length, bytesUsed: -bytesUsed },
+        { imageCount: -deletedImages.length, bytesUsed: -albumBytesUsed },
       ]]))
       setMeta(previous => previous === null
         ? previous
         : {
             ...previous,
             totalImageCount: Math.max(0, previous.totalImageCount - deletedImages.length),
-            totalBytesUsed: Math.max(0, previous.totalBytesUsed - bytesUsed),
+            totalBytesUsed: Math.max(0, previous.totalBytesUsed - releasedBytes),
             updatedAt: new Date().toISOString(),
           })
     }

--- a/src/functions/images.ts
+++ b/src/functions/images.ts
@@ -6,11 +6,14 @@ import type {
   ListAlbumImagesResult,
 } from '@/lib/storage/types'
 import { createServerFn } from '@tanstack/react-start'
+import { and, asc, eq, lt, sql } from 'drizzle-orm'
 import { z } from 'zod'
 import { requireAuth } from '@/lib/auth/guards'
 import { runBulkOperation } from '@/lib/bulk'
 import { getD1Binding, getR2Binding } from '@/lib/cloudflare/bindings'
 import { buildPublicImageUrl, getR2PublicDomain } from '@/lib/cloudflare/publicUrl'
+import { getDb } from '@/lib/db/client'
+import { imagesTable, orphanImageCleanupTable, storageReservationsTable } from '@/lib/db/schema'
 import { validateUploadImage } from '@/lib/images/uploadValidation'
 import { albumExists } from '@/lib/storage/albumsRepo'
 import { normalizeImageExt, normalizeImageMime, toStoredName } from '@/lib/storage/format'
@@ -35,6 +38,8 @@ import {
 
 const BULK_OPERATION_CONCURRENCY = 4
 const BULK_OPERATION_TIMEOUT_MS = 20_000
+const UPLOAD_RESERVATION_GRACE_MS = 15 * 60 * 1000
+const UPLOAD_RECONCILIATION_LIMIT = 3
 
 function normalizeDimensionValue(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null
@@ -58,6 +63,137 @@ const uploadDashboardSchema = z.object({
   albumId: z.string().min(1),
 })
 
+async function recordOrphanUploadCleanup(objectKey: string, error: unknown): Promise<void> {
+  const message = error instanceof Error ? error.message : String(error)
+  const db = getDb()
+  await db
+    .insert(orphanImageCleanupTable)
+    .values({
+      objectKey,
+      cleanupAttempts: 1,
+      cleanupError: message.slice(0, 500),
+      createdAt: Date.now(),
+    })
+    .onConflictDoUpdate({
+      target: orphanImageCleanupTable.objectKey,
+      set: {
+        cleanupAttempts: sql`${orphanImageCleanupTable.cleanupAttempts} + 1`,
+        cleanupError: message.slice(0, 500),
+      },
+    })
+}
+
+async function imageMetadataExists(objectKey: string): Promise<boolean> {
+  const db = getDb()
+  const [image] = await db
+    .select({ id: imagesTable.id })
+    .from(imagesTable)
+    .where(eq(imagesTable.id, objectKey))
+    .limit(1)
+  return image !== undefined
+}
+
+async function uploadMetadataMatches(image: ImageRecord): Promise<boolean> {
+  const [storedImage] = await getDb()
+    .select({ id: imagesTable.id })
+    .from(imagesTable)
+    .where(and(
+      eq(imagesTable.id, image.objectKey),
+      eq(imagesTable.albumId, image.albumId),
+      eq(imagesTable.bytes, image.sizeBytes),
+      eq(imagesTable.storedName, image.storedName),
+      eq(imagesTable.source, image.source),
+      eq(imagesTable.createdAt, Date.parse(image.createdAt)),
+    ))
+    .limit(1)
+  return storedImage !== undefined
+}
+
+type ImageMetadataState = 'present' | 'absent' | 'unknown'
+
+async function getImageMetadataState(image: ImageRecord): Promise<ImageMetadataState> {
+  try {
+    return await uploadMetadataMatches(image) ? 'present' : 'absent'
+  }
+  catch (error) {
+    console.error('[uploadImageFn] Failed to determine whether metadata committed:', error)
+    return 'unknown'
+  }
+}
+
+async function releaseStorageReservation(objectKey: string): Promise<void> {
+  await getDb().delete(storageReservationsTable).where(eq(storageReservationsTable.objectKey, objectKey))
+}
+
+/**
+ * Cleans an R2 object only after its metadata is known not to exist.
+ *
+ * A reservation remains until this succeeds so an uncertain R2 write still
+ * occupies quota and can be retried safely.
+ */
+async function cleanupUncommittedUpload(r2: R2Bucket, objectKey: string, cause: unknown): Promise<void> {
+  try {
+    await deleteImageObject(r2, objectKey)
+    await releaseStorageReservation(objectKey)
+    await getDb().delete(orphanImageCleanupTable).where(eq(orphanImageCleanupTable.objectKey, objectKey))
+  }
+  catch (cleanupError) {
+    try {
+      await recordOrphanUploadCleanup(objectKey, cleanupError)
+    }
+    catch (recordError) {
+      // The reservation is the durable fallback when D1 cannot record the
+      // cleanup error. It is reconciled once D1 becomes available again.
+      console.error('[uploadImageFn] Failed to record orphan upload cleanup:', recordError)
+    }
+    console.error('[uploadImageFn] Failed to clean uncommitted upload:', cause, cleanupError)
+  }
+}
+
+async function reconcilePendingUploads(r2: R2Bucket, limit = UPLOAD_RECONCILIATION_LIMIT): Promise<void> {
+  const db = getDb()
+  const cutoff = Date.now() - UPLOAD_RESERVATION_GRACE_MS
+  const [reservations, orphanMarkers] = await Promise.all([
+    db
+      .select({ objectKey: storageReservationsTable.objectKey })
+      .from(storageReservationsTable)
+      .where(lt(storageReservationsTable.createdAt, cutoff))
+      .orderBy(asc(storageReservationsTable.createdAt), asc(storageReservationsTable.objectKey))
+      .limit(Math.max(1, Math.min(10, limit))),
+    db
+      .select({ objectKey: orphanImageCleanupTable.objectKey })
+      .from(orphanImageCleanupTable)
+      .orderBy(asc(orphanImageCleanupTable.createdAt), asc(orphanImageCleanupTable.objectKey))
+      .limit(Math.max(1, Math.min(10, limit))),
+  ])
+
+  const objectKeys = [...new Set([
+    ...reservations.map(reservation => reservation.objectKey),
+    ...orphanMarkers.map(marker => marker.objectKey),
+  ])]
+
+  for (const objectKey of objectKeys) {
+    try {
+      if (await imageMetadataExists(objectKey)) {
+        // A metadata insert may have committed before its response failed.
+        // Metadata now owns the quota, so remove only the temporary reservation.
+        await releaseStorageReservation(objectKey)
+        await db.delete(orphanImageCleanupTable).where(eq(orphanImageCleanupTable.objectKey, objectKey))
+        continue
+      }
+      await cleanupUncommittedUpload(r2, objectKey, new Error('Reconciliation cleanup'))
+    }
+    catch (error) {
+      try {
+        await recordOrphanUploadCleanup(objectKey, error)
+      }
+      catch (recordError) {
+        console.error('[listImagesFn] Failed to record upload reconciliation error:', recordError)
+      }
+    }
+  }
+}
+
 /**
  * Lists indexed images for one album.
  */
@@ -69,6 +205,9 @@ export const listImagesFn = createServerFn({ method: 'POST' })
     const r2 = getR2Binding()
     await reconcilePendingImageDeletes({ db, r2 }).catch((error) => {
       console.error('[listImagesFn] Failed to reconcile pending image deletions:', error)
+    })
+    await reconcilePendingUploads(r2).catch((error) => {
+      console.error('[listImagesFn] Failed to reconcile pending uploads:', error)
     })
     if (!(await albumExists(db, data.albumId))) {
       throw new Error('Album not found')
@@ -152,14 +291,19 @@ export const uploadImageFn = createServerFn({ method: 'POST' })
     const uploadedAt = new Date().toISOString()
     const { bytes, width, height } = validatedFile
 
-    await putImageObject(r2, {
-      key: objectKey,
-      bytes,
-      mime,
-      albumId,
-      source,
-      uploadedAt,
+    await getDb().insert(storageReservationsTable).values({
+      objectKey,
+      bytesReserved: bytes.byteLength,
+      createdAt: Date.now(),
     })
+
+    try {
+      await putImageObject(r2, { key: objectKey, bytes, mime, albumId, source, uploadedAt })
+    }
+    catch (error) {
+      await cleanupUncommittedUpload(r2, objectKey, error)
+      throw error
+    }
 
     const image: ImageRecord = {
       objectKey,
@@ -182,6 +326,7 @@ export const uploadImageFn = createServerFn({ method: 'POST' })
       albumId,
       name: image.name,
       nameLower: image.name.toLowerCase(),
+      storageBytes: image.sizeBytes + (image.original?.sizeBytes ?? 0),
       sizeBytes: image.sizeBytes,
       mime: image.mime,
       width: image.width,
@@ -189,12 +334,30 @@ export const uploadImageFn = createServerFn({ method: 'POST' })
       createdAt: image.createdAt,
     }
 
+    let metadataCommitted = false
     try {
       await putImageRecords(db, image, albumImage)
+      metadataCommitted = true
     }
     catch (error) {
-      await deleteImageObject(r2, objectKey).catch(() => {})
-      throw error
+      const metadataState = await getImageMetadataState(image)
+      if (metadataState === 'absent') {
+        await cleanupUncommittedUpload(r2, objectKey, error)
+      }
+      if (metadataState !== 'present') {
+        // An unavailable D1 response cannot prove the write rolled back. Keep
+        // the reservation and let bounded reconciliation decide safely later.
+        throw error
+      }
+      metadataCommitted = true
+    }
+
+    if (metadataCommitted) {
+      // INSERT consumes the reservation in a trigger. The no-op delete also
+      // handles a response that arrived after the trigger completed.
+      await releaseStorageReservation(objectKey).catch((error) => {
+        console.error('[uploadImageFn] Failed to release consumed storage reservation:', error)
+      })
     }
 
     let publicUrl: string | null = null

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -52,5 +52,24 @@ export const imagesTable = sqliteTable('images', {
   uniqueIndex('ux_images_original_object_key').on(table.originalObjectKey),
 ])
 
+export const storageQuotaTable = sqliteTable('storage_quota', {
+  id: integer('id').primaryKey(),
+  bytesUsed: integer('bytes_used').notNull(),
+})
+
+export const orphanImageCleanupTable = sqliteTable('orphan_image_cleanup', {
+  objectKey: text('object_key').primaryKey(),
+  cleanupAttempts: integer('cleanup_attempts').notNull().default(0),
+  cleanupError: text('cleanup_error'),
+  createdAt: integer('created_at').notNull(),
+})
+
+export const storageReservationsTable = sqliteTable('storage_reservations', {
+  objectKey: text('object_key').primaryKey(),
+  bytesReserved: integer('bytes_reserved').notNull(),
+  createdAt: integer('created_at').notNull(),
+})
+
 export type AlbumRow = typeof albumsTable.$inferSelect
 export type ImageRow = typeof imagesTable.$inferSelect
+export type StorageQuotaRow = typeof storageQuotaTable.$inferSelect

--- a/src/lib/storage/albumsRepo.ts
+++ b/src/lib/storage/albumsRepo.ts
@@ -2,7 +2,7 @@ import type { AlbumRecord, StorageBootstrapResult, StorageMeta } from '@/lib/sto
 import { eq, isNull, sql } from 'drizzle-orm'
 import { nanoid } from 'nanoid'
 import { getDb } from '@/lib/db/client'
-import { albumsTable, imagesTable } from '@/lib/db/schema'
+import { albumsTable, imagesTable, storageQuotaTable } from '@/lib/db/schema'
 import { ROOT_ALBUM_ID } from '@/lib/storage/types'
 
 function nowMs(): number {
@@ -154,6 +154,12 @@ async function buildStorageMetaInternal(): Promise<StorageMeta> {
     .from(imagesTable)
     .where(isNull(imagesTable.deletedAt))
 
+  const [quota] = await db
+    .select({ bytesUsed: storageQuotaTable.bytesUsed })
+    .from(storageQuotaTable)
+    .where(eq(storageQuotaTable.id, 1))
+    .limit(1)
+
   const updatedAtMs = Math.max(
     albumTotals?.maxUpdatedAt ?? 0,
     imageTotals?.maxUpdatedAt ?? 0,
@@ -163,7 +169,7 @@ async function buildStorageMetaInternal(): Promise<StorageMeta> {
   return {
     rootAlbumId: ROOT_ALBUM_ID,
     defaultAlbumId: defaultAlbum?.id ?? ROOT_ALBUM_ID,
-    totalBytesUsed: imageTotals?.totalBytesUsed ?? 0,
+    totalBytesUsed: quota?.bytesUsed ?? imageTotals?.totalBytesUsed ?? 0,
     totalImageCount: imageTotals?.totalImageCount ?? 0,
     totalAlbumCount: albumTotals?.totalAlbumCount ?? 0,
     updatedAt: toIsoString(updatedAtMs > 0 ? updatedAtMs : nowMs()),

--- a/src/lib/storage/imagesRepo.ts
+++ b/src/lib/storage/imagesRepo.ts
@@ -143,6 +143,7 @@ function toAlbumImageRecord(row: ImageRow): AlbumImageRecord {
     albumId: row.albumId,
     name: row.name,
     nameLower: row.nameLower,
+    storageBytes: row.bytes + (row.originalBytes ?? 0),
     sizeBytes: row.bytes,
     mime: row.mime,
     width: row.width,
@@ -223,33 +224,6 @@ export async function putImageRecords(
       originalWidth: image.original?.width ?? null,
       originalHeight: image.original?.height ?? null,
     })
-    .onConflictDoUpdate({
-      target: imagesTable.id,
-      set: {
-        albumId: image.albumId,
-        name: albumImage.name,
-        nameLower: albumImage.nameLower,
-        ext: image.ext,
-        bytes: image.sizeBytes,
-        width: image.width,
-        height: image.height,
-        createdAt,
-        updatedAt,
-        originalName: image.originalName,
-        storedName: image.storedName,
-        mime: image.mime,
-        source: image.source,
-        originalObjectKey: image.original?.objectKey ?? null,
-        originalBytes: image.original?.sizeBytes ?? null,
-        originalExt: image.original?.ext ?? null,
-        originalMime: image.original?.mime ?? null,
-        originalWidth: image.original?.width ?? null,
-        originalHeight: image.original?.height ?? null,
-        deletedAt: null,
-        cleanupAttempts: 0,
-        cleanupError: null,
-      },
-    })
 }
 
 /**
@@ -298,6 +272,7 @@ export async function listAlbumImages(
       storedName: imagesTable.storedName,
       mime: imagesTable.mime,
       source: imagesTable.source,
+      originalBytes: imagesTable.originalBytes,
     })
     .from(imagesTable)
     .where(conditions.length > 1 ? and(...conditions) : conditions[0])

--- a/src/lib/storage/quota.ts
+++ b/src/lib/storage/quota.ts
@@ -1,0 +1,2 @@
+/** Global storage capacity enforced by D1 metadata triggers. */
+export const STORAGE_QUOTA_BYTES = 5 * 1024 * 1024 * 1024

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -68,6 +68,8 @@ export interface AlbumImageRecord {
   albumId: string
   name: string
   nameLower: string
+  /** Bytes occupied by the derived image and any retained original asset. */
+  storageBytes: number
   sizeBytes: number
   mime: string
   width: number | null


### PR DESCRIPTION
## Summary
- Enforce the 5 GiB storage limit in D1 with trigger-managed usage accounting.
- Reserve capacity before writing R2 objects; safely reconcile orphaned or uncertain writes without deleting objects when metadata status is unknown.
- Include retained-original bytes in storage usage, listing data, and dashboard optimistic updates.

## Key changes
- Adds migration `0004_storage_quota.sql` for quota, reservation, and orphan-cleanup tables plus indexes/triggers.
- Keeps deleted-but-not-yet-cleaned objects charged until R2 cleanup succeeds.
- Separates album active-content usage from global physical storage usage during delete retries.

## Testing
- `pnpm exec tsc --noEmit`
- `pnpm test`
- `pnpm lint` (one pre-existing warning in `DeleteAlbumDialog.tsx`)
- `WRANGLER_LOG_PATH=.wrangler/logs pnpm run build`
- Manual SQLite migration checks: exact-limit acceptance, overflow rejection, reservation conversion, original-byte accounting, and deletion release.

## UI verification
- No browser session was available; dashboard changes were statically and type-checked only.

## Risks / follow-up
- Reconciliation is intentionally bounded (three records per image-list request). A future scheduled/queue worker can move this work off the request path.

### AGENTS.md Update
- Updated: trigger-managed quota and reservation invariant.
- Breaking: No.
- Migration: apply `0004_storage_quota.sql`.
- New env var/binding: N/A.
- Deprecated pattern: direct usage-counter updates -> D1 trigger-managed accounting.