### PR TITLE
fix(navigation): hide dashboard until authenticated

### DIFF
--- a/src/components/layout/Header/HeaderMenu.tsx
+++ b/src/components/layout/Header/HeaderMenu.tsx
@@ -13,21 +13,27 @@ interface MenuItem {
 
 interface HeaderMenuProps {
   isMobile: boolean
+  isLoadingUser: boolean
+  isAuthed: boolean
   ulClassName?: string
   onClickHandler?: () => void
+  onSignedOut: () => void
 }
 
 const HeaderMenu = ({
   isMobile,
+  isLoadingUser,
+  isAuthed,
   ulClassName,
   onClickHandler,
+  onSignedOut,
 }: HeaderMenuProps) => {
   const currentPath = useLocation().pathname
   const { isDarkTheme, toggleTheme } = useTheme('momo-pix-theme-color', 7)
 
   const menuItems: MenuItem[] = [
     { href: '/', label: 'Home', icon: <House /> },
-    { href: '/dashboard', label: 'Dashboard', icon: <LayoutDashboard /> },
+    ...(isAuthed ? [{ href: '/dashboard', label: 'Dashboard', icon: <LayoutDashboard /> }] : []),
   ]
 
   return (
@@ -40,13 +46,17 @@ const HeaderMenu = ({
           href={item.href}
           label={item.label}
           icon={item.icon}
+          onClickHandler={onClickHandler}
         />
       ))}
 
       {/* User Menu */}
       <UserMenu
         isMobile={isMobile}
+        isLoadingUser={isLoadingUser}
+        isAuthed={isAuthed}
         onClickHandler={onClickHandler}
+        onSignedOut={onSignedOut}
       />
 
       {/* Theme Switch */}

--- a/src/components/layout/Header/UserMenu.tsx
+++ b/src/components/layout/Header/UserMenu.tsx
@@ -1,52 +1,33 @@
 import { Link, useNavigate } from '@tanstack/react-router'
 import { useServerFn } from '@tanstack/react-start'
 import { LogIn, LogOut, User } from 'lucide-react'
-import { useEffect, useState, useTransition } from 'react'
+import { useTransition } from 'react'
 import { toast } from 'sonner'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Button } from '@/components/ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { Spinner } from '@/components/ui/spinner'
-import { getCurrentUserFn, logoutFn } from '@/functions/auth'
+import { logoutFn } from '@/functions/auth'
 import HeaderMenuButton from './HeaderMenuButton'
 
 interface UserMenuProps {
   isMobile: boolean
+  isLoadingUser: boolean
+  isAuthed: boolean
   onClickHandler?: () => void
+  onSignedOut: () => void
 }
 
 const UserMenu = ({
   isMobile,
+  isLoadingUser,
+  isAuthed,
   onClickHandler,
+  onSignedOut,
 }: UserMenuProps) => {
   const logout = useServerFn(logoutFn)
-  const getCurrentUser = useServerFn(getCurrentUserFn)
   const navigate = useNavigate()
   const [isSigningOut, startSignout] = useTransition()
-  const [isLoadingUser, setIsLoadingUser] = useState(true)
-  const [isAuthed, setIsAuthed] = useState(false)
-
-  useEffect(() => {
-    let cancelled = false
-
-    void (async () => {
-      try {
-        const user = await getCurrentUser()
-        if (!cancelled) {
-          setIsAuthed(Boolean(user))
-        }
-      }
-      finally {
-        if (!cancelled) {
-          setIsLoadingUser(false)
-        }
-      }
-    })()
-
-    return () => {
-      cancelled = true
-    }
-  }, [getCurrentUser])
 
   const handleSignout = () => {
     startSignout(async () => {
@@ -57,7 +38,7 @@ const UserMenu = ({
           return
         }
 
-        setIsAuthed(false)
+        onSignedOut()
         toast.success('Signed out successfully.')
         await navigate({ to: '/login' })
       }
@@ -88,8 +69,39 @@ const UserMenu = ({
     )
   }
 
+  if (isMobile) {
+    return (
+      <>
+        <li className="flex w-full">
+          <Link
+            to="/dashboard"
+            className="flex w-full items-center gap-4 rounded-lg px-4 py-3 text-lg font-medium no-underline hover:bg-gray-light"
+            onClick={onClickHandler}
+          >
+            <User className="h-5 w-5" aria-hidden />
+            Account
+          </Link>
+        </li>
+        <li className="flex w-full">
+          <Button
+            type="button"
+            variant="ghost"
+            className="flex w-full justify-start gap-4 px-4 py-3 text-lg font-medium"
+            onClick={() => {
+              handleSignout()
+              onClickHandler?.()
+            }}
+          >
+            {isSigningOut ? <Spinner className="h-5 w-5" /> : <LogOut className="h-5 w-5" aria-hidden />}
+            Sign out
+          </Button>
+        </li>
+      </>
+    )
+  }
+
   return (
-    <li className={`${isMobile ? 'mt-4 flex w-full justify-around' : 'flex justify-center gap-4'}`}>
+    <li className="flex justify-center gap-4">
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
@@ -98,7 +110,6 @@ const UserMenu = ({
             size="icon"
             className="text-hover-primary transition-all-300 group h-12 w-12 rounded-full bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
             aria-label="User menu"
-            onClick={onClickHandler}
           >
             <Avatar className="h-8 w-8">
               <AvatarFallback

--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -1,16 +1,59 @@
 import { Link } from '@tanstack/react-router'
+import { useServerFn } from '@tanstack/react-start'
 import { useHideOnScrollDown } from '@zl-asica/react'
 import { Menu, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
+import { getCurrentUserFn } from '@/functions/auth'
 import HeaderMenu from './HeaderMenu'
 
 const Header = () => {
   const [isOpen, setIsOpen] = useState(false)
+  const [isLoadingUser, setIsLoadingUser] = useState(true)
+  const [isAuthed, setIsAuthed] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
   const headerRef = useRef<HTMLElement>(null)
   const isHeaderVisible = useHideOnScrollDown(headerRef)
+  const getCurrentUser = useServerFn(getCurrentUserFn)
+
+  useEffect(() => {
+    let cancelled = false
+
+    void (async () => {
+      try {
+        const user = await getCurrentUser()
+        if (!cancelled) {
+          setIsAuthed(Boolean(user))
+        }
+      }
+      catch (error) {
+        console.error('Failed to load the current user:', error)
+      }
+      finally {
+        if (!cancelled) {
+          setIsLoadingUser(false)
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [getCurrentUser])
+
+  useEffect(() => {
+    const desktopBreakpoint = window.matchMedia('(min-width: 768px)')
+    const closeForDesktop = (event_: MediaQueryListEvent) => {
+      if (event_.matches) {
+        setIsOpen(false)
+      }
+    }
+    desktopBreakpoint.addEventListener('change', closeForDesktop)
+    return () => {
+      desktopBreakpoint.removeEventListener('change', closeForDesktop)
+    }
+  }, [])
 
   const closeMenu = useCallback(() => {
     setIsOpen(false)
@@ -119,8 +162,11 @@ const Header = () => {
           >
             <HeaderMenu
               isMobile
+              isLoadingUser={isLoadingUser}
+              isAuthed={isAuthed}
               ulClassName="flex flex-col items-start gap-4 p-6"
               onClickHandler={closeMenu}
+              onSignedOut={() => setIsAuthed(false)}
             />
           </div>
         )}
@@ -141,7 +187,10 @@ const Header = () => {
         {/* Desktop Menu */}
         <HeaderMenu
           isMobile={false}
+          isLoadingUser={isLoadingUser}
+          isAuthed={isAuthed}
           ulClassName="hidden md:flex md:gap-6"
+          onSignedOut={() => setIsAuthed(false)}
         />
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- Hide the Dashboard navigation item until the current session is authenticated.
- Share one authentication state between desktop and mobile header menus.
- Keep mobile navigation usable across drawer navigation, account actions, sign-out, and desktop breakpoint changes.

## Key changes
- Moves current-user loading from `UserMenu` to `Header`.
- Removes the Dashboard link during loading and for unauthenticated sessions; the server route guard remains the security boundary.
- Replaces the mobile portaled account dropdown with drawer-local Account and Sign out actions.
- Closes the drawer when crossing to the desktop breakpoint, clearing the backdrop and body scroll lock.

## Testing
- `pnpm exec tsc --noEmit`
- `pnpm test`
- `pnpm lint` (one pre-existing warning in `DeleteAlbumDialog.tsx`)
- `WRANGLER_LOG_PATH=.wrangler/logs pnpm run build`

## UI verification
- Static/type/build validation only; no browser automation session was available for manual mobile interaction.

## Risks / follow-up
- The Header refreshes auth state on mount and after local sign-out. A cookie change from another tab is intentionally deferred to a later refresh or navigation guard.