### PR TITLE
perf(images): validate canvas output format

### DIFF
--- a/src/features/home/hooks/useImageTransformQueue.ts
+++ b/src/features/home/hooks/useImageTransformQueue.ts
@@ -2,7 +2,6 @@ import type { CompressionState, HomeProcessedItem } from '@/features/home/types'
 import { nanoid } from 'nanoid'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { getImageDimensions } from '@/lib/images/dimensions'
 import { checkImage, normalizeTransformError, transformImageFile } from '@/lib/img'
 import { shouldKeepOriginalImage } from '@/lib/img/output'
 import { normalizeImageMime } from '@/lib/storage/format'
@@ -117,25 +116,18 @@ export function useImageTransformQueue() {
       targetFormat,
       useManualQuality ? quality : undefined,
     )
-    const compressedFile = toCompressedFile({
-      blob,
-      originalName: item.originalName,
-      targetFormat,
-    })
-
     if (shouldKeepOriginalImage({
       originalSize: item.originalSize,
       outputSize: blob.size,
     })) {
-      const dimensions = await getImageDimensions(item.originalFile)
       return {
         ...item,
         targetFormat,
         outputBlob: item.originalFile,
         outputFile: item.originalFile,
         outputSize: item.originalSize,
-        width: dimensions?.width ?? null,
-        height: dimensions?.height ?? null,
+        width,
+        height,
         status: 'original',
         transformError: 'The original file was kept.',
         uploadStatus: 'idle',
@@ -145,6 +137,12 @@ export function useImageTransformQueue() {
         uploadedAlbumId: null,
       }
     }
+
+    const compressedFile = toCompressedFile({
+      blob,
+      originalName: item.originalName,
+      targetFormat,
+    })
 
     return {
       ...item,

--- a/src/lib/img/transform-client.test.ts
+++ b/src/lib/img/transform-client.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { transformImageFile } from './transform-client'
+
+function stubCanvas(outputType: string) {
+  const drawImage = vi.fn()
+  vi.stubGlobal('document', {
+    createElement: vi.fn(() => ({
+      width: 0,
+      height: 0,
+      getContext: () => ({ drawImage }),
+      toBlob: (callback: BlobCallback) => callback(new Blob(['output'], { type: outputType })),
+    })),
+  })
+  return drawImage
+}
+
+describe('transformImageFile', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns the requested format and closes the decoded bitmap', async () => {
+    const close = vi.fn()
+    const drawImage = stubCanvas('image/webp')
+    vi.stubGlobal('createImageBitmap', vi.fn(async () => ({ width: 640, height: 480, close })))
+
+    const result = await transformImageFile(new File(['input'], 'input.png', { type: 'image/png' }), 'webp', 80)
+
+    expect(result).toMatchObject({ mimeType: 'image/webp', width: 640, height: 480 })
+    expect(result.blob.type).toBe('image/webp')
+    expect(drawImage).toHaveBeenCalledOnce()
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a silent canvas fallback instead of mislabeling the output', async () => {
+    const close = vi.fn()
+    stubCanvas('image/png')
+    vi.stubGlobal('createImageBitmap', vi.fn(async () => ({ width: 640, height: 480, close })))
+
+    const source = new File(['input'], 'input.png', { type: 'image/png' })
+    await expect(transformImageFile(source, 'avif')).rejects.toThrow('This browser cannot encode images as AVIF')
+    expect(close).toHaveBeenCalledOnce()
+  })
+})

--- a/src/lib/img/transform-client.ts
+++ b/src/lib/img/transform-client.ts
@@ -37,6 +37,9 @@ export async function transformImageFile(
     if (!blob) {
       throw new Error(`Unable to encode image as ${format}`)
     }
+    if (blob.type !== mimeType) {
+      throw new Error(`This browser cannot encode images as ${format.toUpperCase()}`)
+    }
 
     return { blob, mimeType, width: bitmap.width, height: bitmap.height }
   }


### PR DESCRIPTION
## Summary
- Prevent Canvas from silently returning PNG when a requested encoder is unsupported.
- Reuse the first decoded bitmap dimensions when a conversion is discarded because it is not smaller.

## Key changes
- Verify `canvas.toBlob()` returns the requested MIME type and show a specific format-support error otherwise.
- Keep `ImageBitmap.close()` in the `finally` path for success and encoding failure.
- Avoid creating a `File` wrapper and a second bitmap decode when the original file is retained.
- Add unit coverage for successful encoding and unsupported-format fallback.

## Testing
- `pnpm exec tsc --noEmit`
- `pnpm test` (25 tests)
- `pnpm lint` (one pre-existing warning in `DeleteAlbumDialog.tsx`)
- `WRANGLER_LOG_PATH=.wrangler/logs pnpm run build`

## UI verification
- No browser automation session was available. The unsupported encoder behavior is covered with mocked Canvas output; real AVIF/WebP encoding should also be smoke-tested in target browsers.

## Notes
- The sequential transform queue is intentionally retained: it bounds browser memory while decoding large images. A Worker/OffscreenCanvas architecture remains a future enhancement rather than a prerequisite for correctness.