### PR TITLE
fix(home): preserve animated uploads

### DIFF
--- a/src/features/home/hooks/useImageTransformQueue.ts
+++ b/src/features/home/hooks/useImageTransformQueue.ts
@@ -111,11 +111,30 @@ export function useImageTransformQueue() {
   }, [])
 
   const transformOne = useCallback(async (item: HomeProcessedItem): Promise<HomeProcessedItem> => {
-    const { blob, width, height } = await transformImageFile(
+    const transformed = await transformImageFile(
       item.originalFile,
       targetFormat,
       useManualQuality ? quality : undefined,
     )
+    const { blob, width, height } = transformed
+    if (transformed.preservedOriginal) {
+      return {
+        ...item,
+        targetFormat,
+        outputBlob: item.originalFile,
+        outputFile: item.originalFile,
+        outputSize: item.originalSize,
+        width,
+        height,
+        status: 'original',
+        transformError: 'Animated images are uploaded unchanged.',
+        uploadStatus: 'idle',
+        uploadError: null,
+        uploadedUrl: null,
+        uploadedObjectKey: null,
+        uploadedAlbumId: null,
+      }
+    }
     if (shouldKeepOriginalImage({
       originalSize: item.originalSize,
       outputSize: blob.size,

--- a/src/lib/img/animation.ts
+++ b/src/lib/img/animation.ts
@@ -1,0 +1,115 @@
+function readU32BE(bytes: Uint8Array, offset: number): number | null {
+  if (offset < 0 || offset + 4 > bytes.length) {
+    return null
+  }
+  return ((bytes[offset] * 2 ** 24) + (bytes[offset + 1] << 16) + (bytes[offset + 2] << 8) | bytes[offset + 3]) >>> 0
+}
+
+function hasAscii(bytes: Uint8Array, offset: number, value: string): boolean {
+  return offset >= 0
+    && offset + value.length <= bytes.length
+    && [...value].every((character, index) => bytes[offset + index] === character.charCodeAt(0))
+}
+
+function skipGifSubBlocks(bytes: Uint8Array, start: number): number | null {
+  let offset = start
+  while (offset < bytes.length) {
+    const size = bytes[offset]
+    offset += 1
+    if (size === 0) {
+      return offset
+    }
+    if (offset + size > bytes.length) {
+      return null
+    }
+    offset += size
+  }
+  return null
+}
+
+function isAnimatedGif(bytes: Uint8Array): boolean {
+  if (!hasAscii(bytes, 0, 'GIF87a') && !hasAscii(bytes, 0, 'GIF89a')) {
+    return false
+  }
+
+  let offset = 13
+  const packedFields = bytes[10]
+  if (packedFields === undefined) {
+    return false
+  }
+  if ((packedFields & 0x80) !== 0) {
+    offset += 3 * (2 ** ((packedFields & 0x07) + 1))
+  }
+
+  let frameCount = 0
+  while (offset < bytes.length) {
+    const blockType = bytes[offset]
+    offset += 1
+
+    if (blockType === 0x3B) {
+      return false
+    }
+
+    if (blockType === 0x21) {
+      // Extension label followed by GIF data sub-blocks.
+      offset += 1
+      const nextOffset = skipGifSubBlocks(bytes, offset)
+      if (nextOffset === null) {
+        return false
+      }
+      offset = nextOffset
+      continue
+    }
+
+    if (blockType !== 0x2C || offset + 9 > bytes.length) {
+      return false
+    }
+
+    const imagePackedFields = bytes[offset + 8]
+    offset += 9
+    if ((imagePackedFields & 0x80) !== 0) {
+      offset += 3 * (2 ** ((imagePackedFields & 0x07) + 1))
+    }
+    // LZW minimum code size precedes the image's data sub-blocks.
+    offset += 1
+    const nextOffset = skipGifSubBlocks(bytes, offset)
+    if (nextOffset === null) {
+      return false
+    }
+    offset = nextOffset
+    frameCount += 1
+    if (frameCount > 1) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function isAnimatedPng(bytes: Uint8Array): boolean {
+  if (!hasAscii(bytes, 1, 'PNG')) {
+    return false
+  }
+
+  let offset = 8
+  while (offset + 12 <= bytes.length) {
+    const length = readU32BE(bytes, offset)
+    if (length === null || offset + 12 + length > bytes.length) {
+      return false
+    }
+    if (hasAscii(bytes, offset + 4, 'acTL')) {
+      return true
+    }
+    offset += 12 + length
+  }
+
+  return false
+}
+
+/**
+ * Detects supported animated raster formats before the canvas path decodes a
+ * single frame and would silently flatten the animation.
+ */
+export function isAnimatedRaster(bytes: Uint8Array): boolean {
+  return isAnimatedGif(bytes) || isAnimatedPng(bytes)
+}

--- a/src/lib/img/transform-client.test.ts
+++ b/src/lib/img/transform-client.test.ts
@@ -1,6 +1,39 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { transformImageFile } from './transform-client'
 
+function pngHeader(width: number, height: number): Uint8Array {
+  return new Uint8Array([
+    0x89,
+    ...new TextEncoder().encode('PNG'),
+    0x0D,
+    0x0A,
+    0x1A,
+    0x0A,
+    0,
+    0,
+    0,
+    13,
+    ...new TextEncoder().encode('IHDR'),
+    (width >>> 24) & 0xFF,
+    (width >>> 16) & 0xFF,
+    (width >>> 8) & 0xFF,
+    width & 0xFF,
+    (height >>> 24) & 0xFF,
+    (height >>> 16) & 0xFF,
+    (height >>> 8) & 0xFF,
+    height & 0xFF,
+    8,
+    6,
+    0,
+    0,
+    0,
+  ])
+}
+
+function pngFile(width = 640, height = 480): File {
+  return new File([pngHeader(width, height)], 'input.png', { type: 'image/png' })
+}
+
 function stubCanvas(outputType: string) {
   const drawImage = vi.fn()
   vi.stubGlobal('document', {
@@ -24,9 +57,9 @@ describe('transformImageFile', () => {
     const drawImage = stubCanvas('image/webp')
     vi.stubGlobal('createImageBitmap', vi.fn(async () => ({ width: 640, height: 480, close })))
 
-    const result = await transformImageFile(new File(['input'], 'input.png', { type: 'image/png' }), 'webp', 80)
+    const result = await transformImageFile(pngFile(), 'webp', 80)
 
-    expect(result).toMatchObject({ mimeType: 'image/webp', width: 640, height: 480 })
+    expect(result).toMatchObject({ mimeType: 'image/webp', width: 640, height: 480, preservedOriginal: false })
     expect(result.blob.type).toBe('image/webp')
     expect(drawImage).toHaveBeenCalledOnce()
     expect(close).toHaveBeenCalledOnce()
@@ -37,8 +70,114 @@ describe('transformImageFile', () => {
     stubCanvas('image/png')
     vi.stubGlobal('createImageBitmap', vi.fn(async () => ({ width: 640, height: 480, close })))
 
-    const source = new File(['input'], 'input.png', { type: 'image/png' })
+    const source = pngFile()
     await expect(transformImageFile(source, 'avif')).rejects.toThrow('This browser cannot encode images as AVIF')
     expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('keeps animated GIFs unchanged instead of flattening them to one frame', async () => {
+    const animatedGif = new Uint8Array([
+      ...new TextEncoder().encode('GIF89a'),
+      1,
+      0,
+      1,
+      0,
+      0,
+      0,
+      0,
+      0x2C,
+      0,
+      0,
+      0,
+      0,
+      1,
+      0,
+      1,
+      0,
+      0,
+      2,
+      2,
+      0x4C,
+      1,
+      0,
+      0x2C,
+      0,
+      0,
+      0,
+      0,
+      1,
+      0,
+      1,
+      0,
+      0,
+      2,
+      2,
+      0x4C,
+      1,
+      0,
+      0x3B,
+    ])
+    const source = new File([animatedGif], 'animated.gif', { type: 'image/gif' })
+    const createImageBitmap = vi.fn()
+    vi.stubGlobal('createImageBitmap', createImageBitmap)
+
+    const result = await transformImageFile(source, 'webp')
+
+    expect(result).toMatchObject({
+      blob: source,
+      mimeType: 'image/gif',
+      width: 1,
+      height: 1,
+      preservedOriginal: true,
+    })
+    expect(createImageBitmap).not.toHaveBeenCalled()
+  })
+
+  it('keeps APNGs unchanged instead of flattening them to one frame', async () => {
+    const animatedPng = new Uint8Array([
+      ...pngHeader(1, 1),
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      8,
+      ...new TextEncoder().encode('acTL'),
+      0,
+      0,
+      0,
+      2,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+    ])
+    const source = new File([animatedPng], 'animated.png', { type: 'image/apng' })
+    const createImageBitmap = vi.fn()
+    vi.stubGlobal('createImageBitmap', createImageBitmap)
+
+    const result = await transformImageFile(source, 'webp')
+
+    expect(result).toMatchObject({
+      blob: source,
+      mimeType: 'image/png',
+      preservedOriginal: true,
+    })
+    expect(createImageBitmap).not.toHaveBeenCalled()
+  })
+
+  it('rejects oversized images before creating a canvas bitmap', async () => {
+    const source = pngFile(8192, 8192)
+    const createImageBitmap = vi.fn()
+    vi.stubGlobal('createImageBitmap', createImageBitmap)
+
+    await expect(transformImageFile(source, 'webp')).rejects.toThrow('24 megapixel transform limit')
+    expect(createImageBitmap).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/img/transform-client.ts
+++ b/src/lib/img/transform-client.ts
@@ -1,8 +1,26 @@
+import { parseUploadImage } from '@/lib/images/uploadValidation'
+import { isAnimatedRaster } from './animation'
 import { OUTPUT_MIME_TYPE_BY_FORMAT } from './constants'
+
+/**
+ * Largest image the browser transform path will decode and paint.
+ *
+ * A canvas needs at least four bytes per pixel, so this keeps the working
+ * bitmap below roughly 96 MiB before encoder overhead on mobile devices.
+ */
+export const MAX_TRANSFORM_PIXELS = 24_000_000
 
 /** Normalized image transform error returned to UI. */
 export interface TransformError {
   message: string
+}
+
+interface TransformImageResult {
+  blob: Blob
+  mimeType: string
+  width: number
+  height: number
+  preservedOriginal: boolean
 }
 
 /**
@@ -12,7 +30,25 @@ export async function transformImageFile(
   file: File,
   format: SupportedFormat,
   quality?: number,
-): Promise<{ blob: Blob, mimeType: string, width: number, height: number }> {
+): Promise<TransformImageResult> {
+  const bytes = new Uint8Array(await file.arrayBuffer())
+  const inputMetadata = parseUploadImage(bytes)
+  if (!inputMetadata) {
+    throw new Error('Unable to read image dimensions')
+  }
+  if (inputMetadata.width * inputMetadata.height > MAX_TRANSFORM_PIXELS) {
+    throw new Error(`Image dimensions exceed the ${MAX_TRANSFORM_PIXELS / 1_000_000} megapixel transform limit`)
+  }
+  if (isAnimatedRaster(bytes)) {
+    return {
+      blob: file,
+      mimeType: inputMetadata.mime,
+      width: inputMetadata.width,
+      height: inputMetadata.height,
+      preservedOriginal: true,
+    }
+  }
+
   const bitmap = await createImageBitmap(file)
 
   try {
@@ -41,7 +77,13 @@ export async function transformImageFile(
       throw new Error(`This browser cannot encode images as ${format.toUpperCase()}`)
     }
 
-    return { blob, mimeType, width: bitmap.width, height: bitmap.height }
+    return {
+      blob,
+      mimeType,
+      width: bitmap.width,
+      height: bitmap.height,
+      preservedOriginal: false,
+    }
   }
   finally {
     bitmap.close()


### PR DESCRIPTION
## Summary

- preserve GIF and APNG uploads instead of flattening them through a one-frame canvas transform
- reject images above the 24MP client transform limit before decoding/allocating a canvas
- retain Canvas MIME validation for static images

## Testing

- `pnpm exec vitest run src/lib/img/transform-client.test.ts src/lib/images/uploadValidation.test.ts`
- pre-push production build

## UI verification

Static and unit verification only; a browser runtime was not available for manual animation playback testing.