### PR TITLE
fix(home): keep upload state recoverable

### DIFF
--- a/src/features/home/components/HomeFeature.tsx
+++ b/src/features/home/components/HomeFeature.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { useCompressedDownloads } from '@/features/home/hooks/useCompressedDownloads'
 import { useCopyLinks } from '@/features/home/hooks/useCopyLinks'
@@ -45,8 +46,11 @@ export function HomeFeature() {
     uploadDialogOpen,
     setUploadDialogOpen,
     selectedAlbumId,
+    accountDataError,
     setSelectedAlbumId,
     isLoadingAccountData,
+    isRefreshingAccountData,
+    reloadAccountData,
     uploadState,
     uploadSummary,
     uploadSelected,
@@ -60,6 +64,7 @@ export function HomeFeature() {
 
   const isUploading = uploadState === 'uploading'
   const isActionLocked = isTransforming || isUploading
+  const isUploadAccountUnavailable = accountDataError !== null
 
   const copyItems = useMemo(() => {
     return items.map(item => ({
@@ -120,6 +125,22 @@ export function HomeFeature() {
               </CardContent>
             </Card>
           )}
+          {isAuthed && isUploadAccountUnavailable && (
+            <Card role="alert">
+              <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-6 text-sm">
+                <p>Could not load upload albums. Retry before uploading images.</p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={isRefreshingAccountData || isUploading}
+                  onClick={reloadAccountData}
+                >
+                  {isRefreshingAccountData ? 'Retrying...' : 'Retry'}
+                </Button>
+              </CardContent>
+            </Card>
+          )}
         </div>
 
         <div className="min-w-0">
@@ -138,6 +159,7 @@ export function HomeFeature() {
             isAllSelected={selection.isAllSelected}
             isIndeterminate={selection.isIndeterminate}
             selectionDisabled={isActionLocked}
+            uploadDisabled={isUploadAccountUnavailable}
             actionDisabled={isActionLocked}
             downloadingAll={downloadingAll}
             onToggleSelected={(id, selected) => {
@@ -167,6 +189,9 @@ export function HomeFeature() {
               void retryTransform(id)
             }}
             onUploadSelectedClick={() => {
+              if (isUploadAccountUnavailable) {
+                return
+              }
               setUploadDialogOpen(true)
             }}
           />

--- a/src/features/home/components/ResultsList.tsx
+++ b/src/features/home/components/ResultsList.tsx
@@ -22,6 +22,7 @@ interface ResultsListProps {
   isAllSelected: boolean
   isIndeterminate: boolean
   selectionDisabled: boolean
+  uploadDisabled: boolean
   actionDisabled: boolean
   downloadingAll: boolean
   onToggleSelected: (id: string, selected: boolean) => void
@@ -51,6 +52,7 @@ export function ResultsList({
   isAllSelected,
   isIndeterminate,
   selectionDisabled,
+  uploadDisabled,
   actionDisabled,
   downloadingAll,
   onToggleSelected,
@@ -146,7 +148,7 @@ export function ResultsList({
                 size="sm"
                 loading={isUploading}
                 loadingText="Uploading..."
-                disabled={selectionDisabled || selectedCount === 0}
+                disabled={selectionDisabled || uploadDisabled || selectedCount === 0}
                 onClick={onUploadSelectedClick}
               >
                 Upload selected (

--- a/src/features/home/components/UploadSelectedDialog.tsx
+++ b/src/features/home/components/UploadSelectedDialog.tsx
@@ -1,6 +1,7 @@
 import type { AlbumRecord } from '@/lib/storage/types'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
 import { LoadingButton } from '@/components/ui/loading-button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 
@@ -48,8 +49,9 @@ export function UploadSelectedDialog({
         </DialogHeader>
 
         <div className="space-y-2">
+          <Label htmlFor="upload-selected-album">Upload to album</Label>
           <Select value={selectedAlbumId} onValueChange={onSelectAlbum} disabled={isPending}>
-            <SelectTrigger className="w-full">
+            <SelectTrigger id="upload-selected-album" className="w-full">
               <SelectValue placeholder="Choose album" />
             </SelectTrigger>
             <SelectContent>

--- a/src/features/home/hooks/useUploadSelected.ts
+++ b/src/features/home/hooks/useUploadSelected.ts
@@ -22,7 +22,6 @@ import { uploadImageFn } from '@/functions/images'
 import { runBulkOperation } from '@/lib/bulk'
 
 const UPLOAD_CONCURRENCY = 3
-const UPLOAD_TIMEOUT_MS = 45_000
 
 const EMPTY_ALBUMS: AlbumRecord[] = []
 
@@ -337,8 +336,10 @@ export function useUploadSelected(
           }
         },
         {
+          // A client-side timeout only rejects the wrapper; it cannot cancel
+          // the server write. Waiting for the actual request outcome avoids
+          // unlocking a retry that could create a duplicate upload.
           concurrency: UPLOAD_CONCURRENCY,
-          timeoutMs: UPLOAD_TIMEOUT_MS,
         },
       )
 


### PR DESCRIPTION
## Summary

- remove the client-only 45-second bulk-upload timeout that could mark an active server write as failed
- keep upload controls locked until each upload request reaches a real outcome
- show a recoverable album-loading error with Retry and disable upload while destinations are unavailable
- label the album selection control

## Testing

- `pnpm exec vitest run src/lib/bulk.test.ts src/lib/img/transform-client.test.ts`
- pre-push production build

## UI verification

Static verification only; browser runtime was unavailable for manual retry-flow testing.