### PR TITLE
fix(dashboard): recover failed data loads

### DIFF
--- a/src/features/dashboard/components/AlbumImagePagination.tsx
+++ b/src/features/dashboard/components/AlbumImagePagination.tsx
@@ -89,7 +89,7 @@ export function AlbumImagePagination({
         <div className="flex items-center gap-2">
           <span className="text-sm text-muted-foreground">Page size</span>
           <Select value={String(pageSize)} onValueChange={value => onPageSizeChange(Number(value))}>
-            <SelectTrigger size="sm" className="w-20">
+            <SelectTrigger size="sm" className="w-20" aria-label="Images per page">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/src/features/dashboard/components/DashboardFeature.tsx
+++ b/src/features/dashboard/components/DashboardFeature.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from '@tanstack/react-router'
 import { ImageIcon } from 'lucide-react'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Spinner } from '@/components/ui/spinner'
 import { AlbumImagePagination } from '@/features/dashboard/components/AlbumImagePagination'
@@ -91,6 +92,9 @@ export function DashboardFeature() {
     selectAlbum,
     uploadFiles,
     retryFailedUploads,
+    reloadAlbums,
+    retryImages,
+    albumsStatus,
   } = useDashboardData({
     urlState,
     onUrlStateChange,
@@ -135,6 +139,30 @@ export function DashboardFeature() {
       <UsageSummary meta={meta} totalSpaceBytes={STORAGE_QUOTA_BYTES} />
     </div>
   ), [albums, meta, selectedAlbumId, selectAlbum, setDefaultAlbum, setMobileSidebarOpen, setPendingDeleteAlbumId])
+
+  if (albumsStatus.state === 'error') {
+    return (
+      <DashboardLayout
+        title="Dashboard"
+        description="Manage uploaded images and albums."
+        sidebar={sidebar}
+        mobileSidebarOpen={mobileSidebarOpen}
+        onMobileSidebarOpenChange={setMobileSidebarOpen}
+      >
+        <Card>
+          <CardHeader>
+            <CardTitle>Dashboard unavailable</CardTitle>
+            <CardDescription>We could not load your albums. Check your connection and try again.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button type="button" onClick={() => void reloadAlbums()} disabled={albumsStatus.isLoading}>
+              {albumsStatus.isLoading ? 'Retrying...' : 'Retry'}
+            </Button>
+          </CardContent>
+        </Card>
+      </DashboardLayout>
+    )
+  }
 
   return (
     <DashboardLayout
@@ -216,39 +244,45 @@ export function DashboardFeature() {
           />
         </CardHeader>
         <CardContent>
-          {imagesStatus.state === 'error' && imagesStatus.error !== null && (
-            <p role="alert" className="mb-3 text-sm text-destructive">
-              Failed to load images:
-              {' '}
-              {imagesStatus.error}
-            </p>
-          )}
-          {imageUrlError !== null && (
-            <p role="alert" className="mb-3 text-sm text-destructive">
-              Image preview URL error:
-              {' '}
-              {imageUrlError}
-            </p>
-          )}
-          <ImagesTable
-            table={table}
-            isInitialLoading={imagesStatus.isInitialLoading}
-            hasLoadedOnce={imagesStatus.hasLoadedOnce}
-          />
-          <div className="mt-4">
-            <AlbumImagePagination
-              pageIndex={pageIndex}
-              totalPages={totalPages}
-              totalCount={totalCount}
-              pageSize={pageSize}
-              hasPreviousPage={hasPreviousPage}
-              hasNextPage={hasNextPage}
-              isLoading={imagesStatus.isFetching}
-              onPageSizeChange={onPageSizeChange}
-              onPreviousPage={goPrevPage}
-              onNextPage={goNextPage}
-            />
-          </div>
+          {imagesStatus.state === 'error'
+            ? (
+                <div role="alert" className="space-y-3 rounded-md border border-destructive/30 p-4 text-sm">
+                  <p>We could not load these images. Check your connection and try again.</p>
+                  <Button type="button" variant="outline" onClick={retryImages} disabled={imagesStatus.isFetching}>
+                    Retry
+                  </Button>
+                </div>
+              )
+            : (
+                <>
+                  {imageUrlError !== null && (
+                    <p role="alert" className="mb-3 text-sm text-destructive">
+                      Image preview URL error:
+                      {' '}
+                      {imageUrlError}
+                    </p>
+                  )}
+                  <ImagesTable
+                    table={table}
+                    isInitialLoading={imagesStatus.isInitialLoading}
+                    hasLoadedOnce={imagesStatus.hasLoadedOnce}
+                  />
+                  <div className="mt-4">
+                    <AlbumImagePagination
+                      pageIndex={pageIndex}
+                      totalPages={totalPages}
+                      totalCount={totalCount}
+                      pageSize={pageSize}
+                      hasPreviousPage={hasPreviousPage}
+                      hasNextPage={hasNextPage}
+                      isLoading={imagesStatus.isFetching}
+                      onPageSizeChange={onPageSizeChange}
+                      onPreviousPage={goPrevPage}
+                      onNextPage={goNextPage}
+                    />
+                  </div>
+                </>
+              )}
         </CardContent>
       </Card>
 

--- a/src/features/dashboard/components/DashboardTopbar.tsx
+++ b/src/features/dashboard/components/DashboardTopbar.tsx
@@ -40,6 +40,7 @@ export function DashboardTopbar({
           <Search className="pointer-events-none absolute top-2.5 left-2 h-4 w-4 text-muted-foreground" />
           <Input
             className="pl-8"
+            aria-label="Search images"
             placeholder="Search images..."
             value={search}
             onChange={event_ => onSearchChange(event_.target.value)}
@@ -59,6 +60,7 @@ export function DashboardTopbar({
           type="file"
           multiple
           accept="image/*"
+          aria-label="Upload image files"
           className="hidden"
           onChange={event_ => onUploadChange(event_.target.files)}
         />

--- a/src/features/dashboard/dialogs/AlbumDialogs.tsx
+++ b/src/features/dashboard/dialogs/AlbumDialogs.tsx
@@ -202,13 +202,13 @@ export function AlbumDialogs({
             <createAlbumForm.Field name="parentId">
               {field => (
                 <div className="space-y-2">
-                  <Label>Parent Album</Label>
+                  <Label htmlFor="create-album-parent">Parent Album</Label>
                   <Select
                     value={field.state.value}
                     onValueChange={value => field.handleChange(value)}
                     disabled={isCreatingPending}
                   >
-                    <SelectTrigger className="w-full">
+                    <SelectTrigger id="create-album-parent" className="w-full" aria-label="Parent album">
                       <SelectValue placeholder="Select parent" />
                     </SelectTrigger>
                     <SelectContent>
@@ -329,13 +329,13 @@ export function AlbumDialogs({
             <moveAlbumForm.Field name="parentId">
               {field => (
                 <div className="space-y-2">
-                  <Label>New Parent</Label>
+                  <Label htmlFor="move-album-parent">New Parent</Label>
                   <Select
                     value={field.state.value}
                     onValueChange={value => field.handleChange(value)}
                     disabled={isMovingPending}
                   >
-                    <SelectTrigger className="w-full">
+                    <SelectTrigger id="move-album-parent" className="w-full" aria-label="New parent album">
                       <SelectValue placeholder="Select parent" />
                     </SelectTrigger>
                     <SelectContent>

--- a/src/features/dashboard/dialogs/BulkMoveImagesDialog.tsx
+++ b/src/features/dashboard/dialogs/BulkMoveImagesDialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useTransition } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
 import { LoadingButton } from '@/components/ui/loading-button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 
@@ -97,12 +98,13 @@ export function BulkMoveImagesDialog({
               const error = field.state.meta.errors.find(item => typeof item === 'string')
               return (
                 <div className="space-y-1">
+                  <Label htmlFor="bulk-move-target-album">Destination album</Label>
                   <Select
                     value={field.state.value}
                     onValueChange={value => field.handleChange(value)}
                     disabled={isPending}
                   >
-                    <SelectTrigger className="w-full">
+                    <SelectTrigger id="bulk-move-target-album" className="w-full" aria-label="Destination album">
                       <SelectValue placeholder="Target album" />
                     </SelectTrigger>
                     <SelectContent>

--- a/src/features/dashboard/dialogs/RenameImageDialog.tsx
+++ b/src/features/dashboard/dialogs/RenameImageDialog.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { LoadingButton } from '@/components/ui/loading-button'
 
 interface RenameImageDialogProps {
@@ -77,14 +78,18 @@ export function RenameImageDialog({
         >
           <renameImageForm.Field name="name">
             {field => (
-              <Input
-                value={field.state.value}
-                onChange={event_ => field.handleChange(event_.target.value)}
-                placeholder="Image name"
-                maxLength={120}
-                autoFocus
-                disabled={isPending}
-              />
+              <div className="space-y-2">
+                <Label htmlFor="rename-image-name">Image name</Label>
+                <Input
+                  id="rename-image-name"
+                  value={field.state.value}
+                  onChange={event_ => field.handleChange(event_.target.value)}
+                  placeholder="Image name"
+                  maxLength={120}
+                  autoFocus
+                  disabled={isPending}
+                />
+              </div>
             )}
           </renameImageForm.Field>
         </form>

--- a/src/features/dashboard/hooks/useDashboardData.ts
+++ b/src/features/dashboard/hooks/useDashboardData.ts
@@ -31,7 +31,7 @@ const SEARCH_DEBOUNCE_MS = 250
  */
 const MAX_SEARCH_DEEP_LINK_PAGE_INDEX = 20
 
-type ImagesState = 'idle' | 'loading' | 'success' | 'error'
+type LoadState = 'idle' | 'loading' | 'success' | 'error'
 
 interface UseDashboardDataOptions {
   urlState: DashboardUrlState
@@ -54,8 +54,8 @@ export function useDashboardData(options: UseDashboardDataOptions) {
   const [selectedAlbumId, setSelectedAlbumId] = useState<string>(urlAlbumId)
   const [images, setImages] = useState<AlbumImageListItem[]>([])
   const [imageUrlError, setImageUrlError] = useState<string | null>(null)
-  const [imagesState, setImagesState] = useState<ImagesState>('idle')
-  const [imagesError, setImagesError] = useState<string | null>(null)
+  const [imagesState, setImagesState] = useState<LoadState>('idle')
+  const [albumsState, setAlbumsState] = useState<LoadState>('idle')
   const [isImagesFetching, setIsImagesFetching] = useState(false)
   const [hasNextPage, setHasNextPage] = useState(false)
   const [pageIndex, setPageIndex] = useState(urlPageIndex)
@@ -87,7 +87,10 @@ export function useDashboardData(options: UseDashboardDataOptions) {
   const totalPages = totalCount === null ? null : Math.max(1, Math.ceil(totalCount / pageSize))
   const hasPreviousPage = pageIndex > 0
   const isFetching = isImagesFetching || isViewTransitionPending
-  const isInitialLoading = !hasLoadedCurrentPage && images.length === 0 && (!hasLoadedAnyPage || imagesState === 'loading' || isImagesFetching)
+  const isInitialLoading = imagesState !== 'error'
+    && !hasLoadedCurrentPage
+    && images.length === 0
+    && (!hasLoadedAnyPage || imagesState === 'loading' || isImagesFetching)
   const isPaginationBusy = isFetching
 
   useLayoutEffect(() => {
@@ -159,7 +162,6 @@ export function useDashboardData(options: UseDashboardDataOptions) {
     imageRequestIdRef.current = requestId
 
     setIsImagesFetching(true)
-    setImagesError(null)
     setImages([])
     setImagesState('loading')
 
@@ -228,13 +230,11 @@ export function useDashboardData(options: UseDashboardDataOptions) {
       setImagesState('success')
       setLoadedPageKey(`${input.viewKey}|${input.pageIndex}`)
     }
-    catch (error) {
+    catch {
       if (requestId !== imageRequestIdRef.current) {
         return
       }
       setImagesState('error')
-      setImagesError(error instanceof Error ? error.message : String(error))
-      throw error
     }
     finally {
       if (requestId === imageRequestIdRef.current) {
@@ -250,6 +250,19 @@ export function useDashboardData(options: UseDashboardDataOptions) {
     setHasNextPage(false)
     setImagesRevision(previous => previous + 1)
   }, [])
+
+  const reloadAlbums = useCallback(async () => {
+    setAlbumsState('loading')
+    setIsAlbumsLoaded(false)
+    try {
+      await loadAlbums()
+      setAlbumsState('success')
+      setIsAlbumsLoaded(true)
+    }
+    catch {
+      setAlbumsState('error')
+    }
+  }, [loadAlbums])
 
   const updateAlbumUsage = useCallback((changes: Map<string, { imageCount: number, bytesUsed: number }>) => {
     setAlbums(previous => previous.map((album) => {
@@ -306,26 +319,8 @@ export function useDashboardData(options: UseDashboardDataOptions) {
   }, [searchQuery])
 
   useEffect(() => {
-    let cancelled = false
-
-    void (async () => {
-      try {
-        await loadAlbums()
-        if (!cancelled) {
-          setIsAlbumsLoaded(true)
-        }
-      }
-      catch (error) {
-        toast.error('Failed to load dashboard', {
-          description: error instanceof Error ? error.message : String(error),
-        })
-      }
-    })()
-
-    return () => {
-      cancelled = true
-    }
-  }, [loadAlbums])
+    void reloadAlbums()
+  }, [reloadAlbums])
 
   useEffect(() => {
     if (!isAlbumsLoaded || !selectedAlbumId) {
@@ -340,10 +335,6 @@ export function useDashboardData(options: UseDashboardDataOptions) {
       query: debouncedSearchQuery,
       viewKey: currentViewKey,
       pageIndex,
-    }).catch((error) => {
-      toast.error('Failed to load images', {
-        description: error instanceof Error ? error.message : String(error),
-      })
     })
   }, [currentPageKey, currentViewKey, debouncedSearchQuery, isAlbumsLoaded, loadedPageKey, loadImages, pageIndex, selectedAlbumId])
 
@@ -606,6 +597,8 @@ export function useDashboardData(options: UseDashboardDataOptions) {
     failedUploadCount,
     uploadFiles,
     retryFailedUploads,
+    reloadAlbums,
+    retryImages: refreshImages,
     createAlbum,
     renameAlbum,
     moveAlbum,
@@ -634,7 +627,10 @@ export function useDashboardData(options: UseDashboardDataOptions) {
       isFetching,
       isInitialLoading,
       hasLoadedOnce: hasLoadedCurrentPage,
-      error: imagesError,
+    },
+    albumsStatus: {
+      state: albumsState,
+      isLoading: albumsState === 'loading',
     },
   }
 }

--- a/src/features/home/components/UploadSelectedDialog.tsx
+++ b/src/features/home/components/UploadSelectedDialog.tsx
@@ -51,7 +51,7 @@ export function UploadSelectedDialog({
         <div className="space-y-2">
           <Label htmlFor="upload-selected-album">Upload to album</Label>
           <Select value={selectedAlbumId} onValueChange={onSelectAlbum} disabled={isPending}>
-            <SelectTrigger id="upload-selected-album" className="w-full">
+            <SelectTrigger id="upload-selected-album" className="w-full" aria-label="Upload to album">
               <SelectValue placeholder="Choose album" />
             </SelectTrigger>
             <SelectContent>

--- a/src/lib/img/transform-client.test.ts
+++ b/src/lib/img/transform-client.test.ts
@@ -31,7 +31,7 @@ function pngHeader(width: number, height: number): Uint8Array {
 }
 
 function pngFile(width = 640, height = 480): File {
-  return new File([pngHeader(width, height)], 'input.png', { type: 'image/png' })
+  return new File([pngHeader(width, height).buffer as ArrayBuffer], 'input.png', { type: 'image/png' })
 }
 
 function stubCanvas(outputType: string) {
@@ -117,7 +117,7 @@ describe('transformImageFile', () => {
       0,
       0x3B,
     ])
-    const source = new File([animatedGif], 'animated.gif', { type: 'image/gif' })
+    const source = new File([animatedGif.buffer], 'animated.gif', { type: 'image/gif' })
     const createImageBitmap = vi.fn()
     vi.stubGlobal('createImageBitmap', createImageBitmap)
 
@@ -158,7 +158,7 @@ describe('transformImageFile', () => {
       0,
       0,
     ])
-    const source = new File([animatedPng], 'animated.png', { type: 'image/apng' })
+    const source = new File([animatedPng.buffer], 'animated.png', { type: 'image/apng' })
     const createImageBitmap = vi.fn()
     vi.stubGlobal('createImageBitmap', createImageBitmap)
 


### PR DESCRIPTION
## Summary

- replace permanent Dashboard skeletons after album/image load failures with actionable error states and Retry
- avoid exposing raw request errors in the dashboard UI
- add accessible names to search, upload, page-size, and dialog controls
- correct the image-transform test `BlobPart` typing so project type checks pass

## Testing

- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/features/dashboard/lib/cursorNavigation.test.ts src/features/dashboard/lib/urlState.test.ts src/features/dashboard/lib/copyFormats.test.ts src/lib/img/transform-client.test.ts`
- pre-push production build

## UI verification

Static, type, and unit verification completed. A browser runtime was unavailable for manually forcing loading-error and retry states.