### PR TITLE
fix(home): preserve animated webp uploads

### DIFF
--- a/src/lib/img/animation.ts
+++ b/src/lib/img/animation.ts
@@ -5,6 +5,13 @@ function readU32BE(bytes: Uint8Array, offset: number): number | null {
   return ((bytes[offset] * 2 ** 24) + (bytes[offset + 1] << 16) + (bytes[offset + 2] << 8) | bytes[offset + 3]) >>> 0
 }
 
+function readU32LE(bytes: Uint8Array, offset: number): number | null {
+  if (offset < 0 || offset + 4 > bytes.length) {
+    return null
+  }
+  return bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16) | (bytes[offset + 3] << 24)
+}
+
 function hasAscii(bytes: Uint8Array, offset: number, value: string): boolean {
   return offset >= 0
     && offset + value.length <= bytes.length
@@ -106,10 +113,33 @@ function isAnimatedPng(bytes: Uint8Array): boolean {
   return false
 }
 
+function isAnimatedWebp(bytes: Uint8Array): boolean {
+  if (!hasAscii(bytes, 0, 'RIFF') || !hasAscii(bytes, 8, 'WEBP')) {
+    return false
+  }
+
+  let offset = 12
+  while (offset + 8 <= bytes.length) {
+    const chunkLength = readU32LE(bytes, offset + 4)
+    if (chunkLength === null || chunkLength < 0 || offset + 8 + chunkLength > bytes.length) {
+      return false
+    }
+    if (hasAscii(bytes, offset, 'ANIM')) {
+      return true
+    }
+    if (hasAscii(bytes, offset, 'VP8X') && (bytes[offset + 8] & 0x02) !== 0) {
+      return true
+    }
+    offset += 8 + chunkLength + (chunkLength % 2)
+  }
+
+  return false
+}
+
 /**
  * Detects supported animated raster formats before the canvas path decodes a
  * single frame and would silently flatten the animation.
  */
 export function isAnimatedRaster(bytes: Uint8Array): boolean {
-  return isAnimatedGif(bytes) || isAnimatedPng(bytes)
+  return isAnimatedGif(bytes) || isAnimatedPng(bytes) || isAnimatedWebp(bytes)
 }

--- a/src/lib/img/transform-client.test.ts
+++ b/src/lib/img/transform-client.test.ts
@@ -172,6 +172,45 @@ describe('transformImageFile', () => {
     expect(createImageBitmap).not.toHaveBeenCalled()
   })
 
+  it('keeps animated WebP images unchanged instead of flattening them to one frame', async () => {
+    const animatedWebp = new Uint8Array([
+      ...new TextEncoder().encode('RIFF'),
+      22,
+      0,
+      0,
+      0,
+      ...new TextEncoder().encode('WEBPVP8X'),
+      10,
+      0,
+      0,
+      0,
+      0x02,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+    ])
+    const source = new File([animatedWebp.buffer], 'animated.webp', { type: 'image/webp' })
+    const createImageBitmap = vi.fn()
+    vi.stubGlobal('createImageBitmap', createImageBitmap)
+
+    const result = await transformImageFile(source, 'webp')
+
+    expect(result).toMatchObject({
+      blob: source,
+      mimeType: 'image/webp',
+      width: 1,
+      height: 1,
+      preservedOriginal: true,
+    })
+    expect(createImageBitmap).not.toHaveBeenCalled()
+  })
+
   it('rejects oversized images before creating a canvas bitmap', async () => {
     const source = pngFile(8192, 8192)
     const createImageBitmap = vi.fn()


### PR DESCRIPTION
## Summary

- detect animated WebP `VP8X`/`ANIM` chunks before Canvas conversion
- retain the original WebP instead of silently flattening its animation
- add coverage for all supported animated inputs: GIF, APNG, and WebP

## Testing

- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/lib/img/transform-client.test.ts src/lib/images/uploadValidation.test.ts`
- pre-push production build

## UI verification

Static and unit verification completed; no browser runtime was available for playback testing.