### PR TITLE
perf(images): harden thumbnail storage and browser memory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,7 @@ SESSION_SECRET=replace-with-long-random-session-secret
 VITE_TURNSTILE_SITE_KEY=replace-with-turnstile-site-key
 TURNSTILE_SECRET_KEY=replace-with-turnstile-secret-key
 
-# Public base URL for direct R2 image rendering (required in dev and production)
+# Public base URL for direct R2 image rendering (required in dev and production).
+# Its R2 CORS policy must allow GET/HEAD from the app origin so authenticated
+# users can generate thumbnails for legacy images in their browser.
 R2_PUBLIC_DOMAIN=https://img.example.com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,8 @@ Usage/accounting:
 - `storage_quota` is maintained only by D1 triggers. Reserve capacity before
   uploading to R2, and retain that reservation until metadata is committed or
   every orphaned asset has been deleted; never update the counter directly.
+- Thumbnail backfills reserve capacity under the derived thumbnail object key;
+  the image UPDATE trigger consumes that reservation atomically with metadata.
 
 UI invariants:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,8 @@ Image URL invariants:
 
 - Build public URLs through shared helpers (single source of truth).
 - Never hardcode public domains in components.
+- Keep the public R2 bucket CORS policy compatible with browser-side legacy
+  thumbnail generation (GET/HEAD from the app origin).
 
 ## 7) Comments, TSDoc, and Readability
 

--- a/migrations/0006_thumbnail_backfill_reservations.sql
+++ b/migrations/0006_thumbnail_backfill_reservations.sql
@@ -1,0 +1,27 @@
+DROP TRIGGER IF EXISTS trg_images_quota_before_update_limit;
+DROP TRIGGER IF EXISTS trg_images_quota_after_update;
+
+CREATE TRIGGER trg_images_quota_before_update_limit
+BEFORE UPDATE OF bytes, original_bytes, thumbnail_bytes ON images
+WHEN (SELECT bytes_used FROM storage_quota WHERE id = 1)
+  + (NEW.bytes + NEW.thumbnail_bytes + COALESCE(NEW.original_bytes, 0))
+  - (OLD.bytes + COALESCE(OLD.thumbnail_bytes, 0) + COALESCE(OLD.original_bytes, 0))
+  - COALESCE((
+    SELECT bytes_reserved
+    FROM storage_reservations
+    WHERE object_key = NEW.thumbnail_object_key
+  ), 0) > 5368709120
+BEGIN
+  SELECT RAISE(ABORT, 'Storage quota exceeded');
+END;
+
+CREATE TRIGGER trg_images_quota_after_update
+AFTER UPDATE OF bytes, original_bytes, thumbnail_bytes ON images
+BEGIN
+  UPDATE storage_quota
+  SET bytes_used = bytes_used
+    + (NEW.bytes + NEW.thumbnail_bytes + COALESCE(NEW.original_bytes, 0))
+    - (OLD.bytes + COALESCE(OLD.thumbnail_bytes, 0) + COALESCE(OLD.original_bytes, 0))
+  WHERE id = 1;
+  DELETE FROM storage_reservations WHERE object_key = NEW.thumbnail_object_key;
+END;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,14 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@1.1.12: 1.1.13
+  esbuild@0.18.20: 0.25.12
+  minimatch@3.1.2: 3.1.4
+  picomatch@2.3.1: 2.3.2
+  rollup: 4.62.2
+  solid-js: 1.9.14
+
 importers:
 
   .:
@@ -64,10 +72,10 @@ importers:
         version: 8.19.4
       '@tanstack/react-devtools':
         specifier: ^0.10.8
-        version: 0.10.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.10)
+        version: 0.10.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.14)
       '@tanstack/react-form':
         specifier: ^1.33.2
-        version: 1.33.2(@tanstack/react-start@1.168.28(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 1.33.2(@tanstack/react-start@1.168.28(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-query':
         specifier: ^5.101.2
         version: 5.101.2(react@19.2.7)
@@ -82,13 +90,13 @@ importers:
         version: 1.167.1(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start':
         specifier: ^1.168.28
-        version: 1.168.28(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 1.168.28(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-plugin':
         specifier: ^1.168.20
-        version: 1.168.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 1.168.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@zl-asica/react':
         specifier: ^0.13.0
         version: 0.13.0(react@19.2.7)
@@ -481,11 +489,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -499,12 +507,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.18.20':
-    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -515,12 +517,6 @@ packages:
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.18.20':
-    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -535,12 +531,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.18.20':
-    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -553,12 +543,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.18.20':
-    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -569,12 +553,6 @@ packages:
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.18.20':
-    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -589,12 +567,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.18.20':
-    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -605,12 +577,6 @@ packages:
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.18.20':
-    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -625,12 +591,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.18.20':
-    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -641,12 +601,6 @@ packages:
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.18.20':
-    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -661,12 +615,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.18.20':
-    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -677,12 +625,6 @@ packages:
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.18.20':
-    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -697,12 +639,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.18.20':
-    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -713,12 +649,6 @@ packages:
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.18.20':
-    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -733,12 +663,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.18.20':
-    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -751,12 +675,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.18.20':
-    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -767,12 +685,6 @@ packages:
     resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.18.20':
-    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -799,12 +711,6 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.18.20':
-    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -827,12 +733,6 @@ packages:
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.18.20':
-    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -859,12 +759,6 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.18.20':
-    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -876,12 +770,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.18.20':
-    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -895,12 +783,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.18.20':
-    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -911,12 +793,6 @@ packages:
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.18.20':
-    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -2529,144 +2405,6 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@rollup/rollup-android-arm-eabi@4.57.1':
-    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.57.1':
-    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-darwin-arm64@4.57.1':
-    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.57.1':
-    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rollup/rollup-freebsd-arm64@4.57.1':
-    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.57.1':
-    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
-    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
-    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-arm64-gnu@4.57.1':
-    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-musl@4.57.1':
-    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-loong64-gnu@4.57.1':
-    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-musl@4.57.1':
-    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
-    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-musl@4.57.1':
-    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
-    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.57.1':
-    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-s390x-gnu@4.57.1':
-    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-gnu@4.57.1':
-    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-musl@4.57.1':
-    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-openbsd-x64@4.57.1':
-    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.57.1':
-    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rollup/rollup-win32-arm64-msvc@4.57.1':
-    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.57.1':
-    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.57.1':
-    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.57.1':
-    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
-    cpu: [x64]
-    os: [win32]
-
   '@sindresorhus/base62@1.0.0':
     resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
     engines: {node: '>=18'}
@@ -2678,32 +2416,32 @@ packages:
   '@solid-primitives/event-listener@2.4.6':
     resolution: {integrity: sha512-5I0YJcTVYIWoMmgBSROBZGcz+ymhew/pGTg2dHW74BUjFKsV8Li4bOZYl0YAGP4mHw5o4UBd9/BEesqBci3wxw==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/keyboard@1.3.7':
     resolution: {integrity: sha512-558RPNYnXx4nGh537DSqAn4xMrC8iFipl/5+xzgzWoTNFst4RnUN3BOLmtDjJ0UGGoQXVMALYR3bNOHM0xnt1Q==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/resize-observer@2.2.0':
     resolution: {integrity: sha512-9Fuu/EWBeGj+atGHRJp70HKhdfalmpjwxY8a32NZixdLNmfCJ45AfhLQNr6uOzETbbiMx4iCKlTrJ8KZCHC2Ww==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/rootless@1.5.4':
     resolution: {integrity: sha512-TOIZa1VUfVJ+9nkCcRajw3U4t9vBOP1HxX1WHNTbXq32mXwlqTvUnC4CRIilohcryBkT9u2ZkhUDSHRTaGp55g==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/static-store@0.1.4':
     resolution: {integrity: sha512-LgtVaVBtB7EbmS4+M0b8xY5Iq6pUWXBsIC4VgtrFKDGDdyCaDt88sHk0fUlx1Enxm/XZnZyLXJABRoa39RjJqA==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@solid-primitives/utils@6.4.1':
     resolution: {integrity: sha512-ISSB5QX1qP2ynrheIpYwc4oKR5Ny4siNuUyf1qZniy+Il+p/PtDB0QK1Dnle8noiHpwRD3gpPdubOC3qI/Zamg==}
     peerDependencies:
-      solid-js: ^1.6.12
+      solid-js: 1.9.14
 
   '@speed-highlight/core@1.2.17':
     resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
@@ -2836,7 +2574,7 @@ packages:
     resolution: {integrity: sha512-CVaM6rT6Nl5ijo83vJYFa2SjofvpuOl/uOvbYGhBrRgUhhelNHhx8zZX+hnZCHmIr0/lzM65hsocnZ72592Rvg==}
     engines: {node: '>=18'}
     peerDependencies:
-      solid-js: '>=1.9.7'
+      solid-js: 1.9.14
 
   '@tanstack/devtools-vite@0.8.1':
     resolution: {integrity: sha512-oQxOo0fI0bwhHtw/psFlIR0OS/bsKrirBxwnw2vuhCM4bjt3k4EZZsW/lvZ1+Vpouhts7LSyvngnxvGXbQ1sUQ==}
@@ -2850,7 +2588,7 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      solid-js: '>=1.9.7'
+      solid-js: 1.9.14
 
   '@tanstack/eslint-plugin-query@5.101.2':
     resolution: {integrity: sha512-cPE99s3XZwlObfn8lCezT4j4JLj2CVzpIEywx0H4hzfPsX/o9QhdwaOwcDXxrQAqx2ds7TbvTinxhB8B/ywb6w==}
@@ -3104,9 +2842,6 @@ packages:
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
-
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -3403,8 +3138,8 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
@@ -3782,11 +3517,6 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
-
-  esbuild@0.18.20:
-    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
-    engines: {node: '>=12'}
-    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -4818,8 +4548,8 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@3.1.4:
+    resolution: {integrity: sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -4955,8 +4685,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
   picomatch@4.0.5:
@@ -5141,11 +4871,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rollup@4.57.1:
-    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rou3@0.8.1:
     resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
@@ -5183,21 +4908,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  seroval-plugins@1.3.3:
-    resolution: {integrity: sha512-16OL3NnUBw8JG1jBLUoZJsLnQq0n5Ua6aHalhJK4fMQkz1lqR7Osz1sA30trBtd9VUDc2NgkuRCn8+/pBwqZ+w==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      seroval: ^1.0
-
   seroval-plugins@1.5.5:
     resolution: {integrity: sha512-+BDhqYM6CEn3x09v44dpa9p6974FuUB2dxk+Ctn04k0cO1Zt6QODTXfmEZK0eBaTe/fJBvP4NMGuNJ+R8T+QMg==}
     engines: {node: '>=10'}
     peerDependencies:
       seroval: ^1.0
-
-  seroval@1.3.2:
-    resolution: {integrity: sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==}
-    engines: {node: '>=10'}
 
   seroval@1.5.5:
     resolution: {integrity: sha512-bSjOuPcwPKLSJNhr9+bZxA20nQxVle5J5MNsYRVE6cIg7KpRLXGupymePavu0jrxlPiPsr4xGZSB8yUY2sH2sw==}
@@ -5268,8 +4983,8 @@ packages:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
 
-  solid-js@1.9.10:
-    resolution: {integrity: sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew==}
+  solid-js@1.9.14:
+    resolution: {integrity: sha512-sAEXC0Kk0S1EDg+8ysEWJDbYhA3RRoEjwuySUGlKIemeo0I5YZfOyumNjNs9Sv3y2nmhD+0rW66ag2HsMuQiGQ==}
 
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
@@ -5502,9 +5217,9 @@ packages:
       '@farmfe/core': '*'
       '@rspack/core': '*'
       bun-types-no-globals: '*'
-      esbuild: '*'
+      esbuild: 0.25.12
       rolldown: '*'
-      rollup: '*'
+      rollup: 4.62.2
       unloader: '*'
       vite: '*'
       webpack: '*'
@@ -6071,7 +5786,7 @@ snapshots:
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
-      esbuild: 0.18.20
+      esbuild: 0.25.12
       source-map-support: 0.5.21
 
   '@esbuild-kit/esm-loader@2.6.5':
@@ -6085,16 +5800,10 @@ snapshots:
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.18.20':
-    optional: true
-
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/android-arm@0.18.20':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
@@ -6103,16 +5812,10 @@ snapshots:
   '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.18.20':
-    optional: true
-
   '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.18.20':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
@@ -6121,16 +5824,10 @@ snapshots:
   '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.18.20':
-    optional: true
-
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
@@ -6139,16 +5836,10 @@ snapshots:
   '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.18.20':
-    optional: true
-
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-arm64@0.18.20':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
@@ -6157,16 +5848,10 @@ snapshots:
   '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.18.20':
-    optional: true
-
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
-    optional: true
-
-  '@esbuild/linux-ia32@0.18.20':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
@@ -6175,16 +5860,10 @@ snapshots:
   '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.18.20':
-    optional: true
-
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.18.20':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
@@ -6193,16 +5872,10 @@ snapshots:
   '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.18.20':
-    optional: true
-
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.18.20':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
@@ -6211,16 +5884,10 @@ snapshots:
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.18.20':
-    optional: true
-
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
-    optional: true
-
-  '@esbuild/linux-x64@0.18.20':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -6235,9 +5902,6 @@ snapshots:
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.18.20':
-    optional: true
-
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -6248,9 +5912,6 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.18.20':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -6265,16 +5926,10 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.18.20':
-    optional: true
-
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.28.1':
-    optional: true
-
-  '@esbuild/win32-arm64@0.18.20':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -6283,16 +5938,10 @@ snapshots:
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.18.20':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.28.1':
-    optional: true
-
-  '@esbuild/win32-x64@0.18.20':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -7759,118 +7408,43 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/rollup-android-arm-eabi@4.57.1':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.57.1':
-    optional: true
-
-  '@rollup/rollup-darwin-arm64@4.57.1':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.57.1':
-    optional: true
-
-  '@rollup/rollup-freebsd-arm64@4.57.1':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.57.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-gnu@4.57.1':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.57.1':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-gnu@4.57.1':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.57.1':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.57.1':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.57.1':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.57.1':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.57.1':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.57.1':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.57.1':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.57.1':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.57.1':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.57.1':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.57.1':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.57.1':
-    optional: true
-
   '@sindresorhus/base62@1.0.0': {}
 
   '@sindresorhus/is@7.2.0': {}
 
-  '@solid-primitives/event-listener@2.4.6(solid-js@1.9.10)':
+  '@solid-primitives/event-listener@2.4.6(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.10)
-      solid-js: 1.9.10
+      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/keyboard@1.3.7(solid-js@1.9.10)':
+  '@solid-primitives/keyboard@1.3.7(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.10)
-      '@solid-primitives/rootless': 1.5.4(solid-js@1.9.10)
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.10)
-      solid-js: 1.9.10
+      '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.14)
+      '@solid-primitives/rootless': 1.5.4(solid-js@1.9.14)
+      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/resize-observer@2.2.0(solid-js@1.9.10)':
+  '@solid-primitives/resize-observer@2.2.0(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.10)
-      '@solid-primitives/rootless': 1.5.4(solid-js@1.9.10)
-      '@solid-primitives/static-store': 0.1.4(solid-js@1.9.10)
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.10)
-      solid-js: 1.9.10
+      '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.14)
+      '@solid-primitives/rootless': 1.5.4(solid-js@1.9.14)
+      '@solid-primitives/static-store': 0.1.4(solid-js@1.9.14)
+      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/rootless@1.5.4(solid-js@1.9.10)':
+  '@solid-primitives/rootless@1.5.4(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.10)
-      solid-js: 1.9.10
+      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/static-store@0.1.4(solid-js@1.9.10)':
+  '@solid-primitives/static-store@0.1.4(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/utils': 6.4.1(solid-js@1.9.10)
-      solid-js: 1.9.10
+      '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
+      solid-js: 1.9.14
 
-  '@solid-primitives/utils@6.4.1(solid-js@1.9.10)':
+  '@solid-primitives/utils@6.4.1(solid-js@1.9.14)':
     dependencies:
-      solid-js: 1.9.10
+      solid-js: 1.9.14
 
   '@speed-highlight/core@1.2.17': {}
 
@@ -7977,12 +7551,12 @@ snapshots:
 
   '@tanstack/devtools-event-client@0.5.0': {}
 
-  '@tanstack/devtools-ui@0.6.0(csstype@3.2.3)(solid-js@1.9.10)':
+  '@tanstack/devtools-ui@0.6.0(csstype@3.2.3)(solid-js@1.9.14)':
     dependencies:
       clsx: 2.1.1
       dayjs: 1.11.21
       goober: 2.1.19(csstype@3.2.3)
-      solid-js: 1.9.10
+      solid-js: 1.9.14
     transitivePeerDependencies:
       - csstype
 
@@ -8002,17 +7576,17 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@tanstack/devtools@0.12.5(csstype@3.2.3)(solid-js@1.9.10)':
+  '@tanstack/devtools@0.12.5(csstype@3.2.3)(solid-js@1.9.14)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.10)
-      '@solid-primitives/keyboard': 1.3.7(solid-js@1.9.10)
-      '@solid-primitives/resize-observer': 2.2.0(solid-js@1.9.10)
+      '@solid-primitives/event-listener': 2.4.6(solid-js@1.9.14)
+      '@solid-primitives/keyboard': 1.3.7(solid-js@1.9.14)
+      '@solid-primitives/resize-observer': 2.2.0(solid-js@1.9.14)
       '@tanstack/devtools-client': 0.0.8
       '@tanstack/devtools-event-bus': 0.4.2
-      '@tanstack/devtools-ui': 0.6.0(csstype@3.2.3)(solid-js@1.9.10)
+      '@tanstack/devtools-ui': 0.6.0(csstype@3.2.3)(solid-js@1.9.14)
       clsx: 2.1.1
       goober: 2.1.19(csstype@3.2.3)
-      solid-js: 1.9.10
+      solid-js: 1.9.14
     transitivePeerDependencies:
       - bufferutil
       - csstype
@@ -8043,9 +7617,9 @@ snapshots:
 
   '@tanstack/query-core@5.101.2': {}
 
-  '@tanstack/react-devtools@0.10.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.10)':
+  '@tanstack/react-devtools@0.10.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.14)':
     dependencies:
-      '@tanstack/devtools': 0.12.5(csstype@3.2.3)(solid-js@1.9.10)
+      '@tanstack/devtools': 0.12.5(csstype@3.2.3)(solid-js@1.9.14)
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
       react: 19.2.7
@@ -8056,13 +7630,13 @@ snapshots:
       - solid-js
       - utf-8-validate
 
-  '@tanstack/react-form@1.33.2(@tanstack/react-start@1.168.28(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tanstack/react-form@1.33.2(@tanstack/react-start@1.168.28(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@tanstack/form-core': 1.33.2
       '@tanstack/react-store': 0.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
     optionalDependencies:
-      '@tanstack/react-start': 1.168.28(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@tanstack/react-start': 1.168.28(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - react-dom
 
@@ -8110,14 +7684,14 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@tanstack/react-start-rsc@0.1.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@tanstack/react-start-rsc@0.1.27(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-core': 1.171.15
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.14
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.17
       '@tanstack/start-storage-context': 1.167.17
       pathe: 2.0.3
@@ -8147,15 +7721,15 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.28(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@tanstack/react-start@1.168.28(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start-client': 1.168.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tanstack/react-start-rsc': 0.1.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@tanstack/react-start-rsc': 0.1.27(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@tanstack/react-start-server': 1.167.22(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.14
-      '@tanstack/start-plugin-core': 1.171.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.17
       pathe: 2.0.3
       react: 19.2.7
@@ -8224,7 +7798,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@tanstack/router-plugin@1.168.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/template': 7.29.7
@@ -8233,7 +7807,7 @@ snapshots:
       '@tanstack/router-generator': 1.167.19
       '@tanstack/router-utils': 1.162.2
       chokidar: 5.0.0
-      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      unplugin: 3.3.0(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-router': 1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -8275,14 +7849,14 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@tanstack/start-plugin-core@1.171.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.7
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.15
       '@tanstack/router-generator': 1.167.19
-      '@tanstack/router-plugin': 1.168.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@tanstack/router-plugin': 1.168.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-server-core': 1.169.17
       exsolve: 1.1.0
@@ -8354,9 +7928,6 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
-
-  '@types/estree@1.0.8':
-    optional: true
 
   '@types/estree@1.0.9': {}
 
@@ -8711,7 +8282,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -9048,31 +8619,6 @@ snapshots:
       is-symbol: 1.1.1
     optional: true
 
-  esbuild@0.18.20:
-    optionalDependencies:
-      '@esbuild/android-arm': 0.18.20
-      '@esbuild/android-arm64': 0.18.20
-      '@esbuild/android-x64': 0.18.20
-      '@esbuild/darwin-arm64': 0.18.20
-      '@esbuild/darwin-x64': 0.18.20
-      '@esbuild/freebsd-arm64': 0.18.20
-      '@esbuild/freebsd-x64': 0.18.20
-      '@esbuild/linux-arm': 0.18.20
-      '@esbuild/linux-arm64': 0.18.20
-      '@esbuild/linux-ia32': 0.18.20
-      '@esbuild/linux-loong64': 0.18.20
-      '@esbuild/linux-mips64el': 0.18.20
-      '@esbuild/linux-ppc64': 0.18.20
-      '@esbuild/linux-riscv64': 0.18.20
-      '@esbuild/linux-s390x': 0.18.20
-      '@esbuild/linux-x64': 0.18.20
-      '@esbuild/netbsd-x64': 0.18.20
-      '@esbuild/openbsd-x64': 0.18.20
-      '@esbuild/sunos-x64': 0.18.20
-      '@esbuild/win32-arm64': 0.18.20
-      '@esbuild/win32-ia32': 0.18.20
-      '@esbuild/win32-x64': 0.18.20
-
   esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
@@ -9254,7 +8800,7 @@ snapshots:
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 3.1.2
+      minimatch: 3.1.4
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
@@ -10474,7 +10020,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
     optional: true
 
   mimic-function@5.0.1: {}
@@ -10495,9 +10041,9 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.7
 
-  minimatch@3.1.2:
+  minimatch@3.1.4:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.13
     optional: true
 
   mlly@1.8.2:
@@ -10673,7 +10219,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1:
+  picomatch@2.3.2:
     optional: true
 
   picomatch@4.0.5: {}
@@ -10934,38 +10480,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
 
-  rollup@4.57.1:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.57.1
-      '@rollup/rollup-android-arm64': 4.57.1
-      '@rollup/rollup-darwin-arm64': 4.57.1
-      '@rollup/rollup-darwin-x64': 4.57.1
-      '@rollup/rollup-freebsd-arm64': 4.57.1
-      '@rollup/rollup-freebsd-x64': 4.57.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
-      '@rollup/rollup-linux-arm64-gnu': 4.57.1
-      '@rollup/rollup-linux-arm64-musl': 4.57.1
-      '@rollup/rollup-linux-loong64-gnu': 4.57.1
-      '@rollup/rollup-linux-loong64-musl': 4.57.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
-      '@rollup/rollup-linux-ppc64-musl': 4.57.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
-      '@rollup/rollup-linux-riscv64-musl': 4.57.1
-      '@rollup/rollup-linux-s390x-gnu': 4.57.1
-      '@rollup/rollup-linux-x64-gnu': 4.57.1
-      '@rollup/rollup-linux-x64-musl': 4.57.1
-      '@rollup/rollup-openbsd-x64': 4.57.1
-      '@rollup/rollup-openharmony-arm64': 4.57.1
-      '@rollup/rollup-win32-arm64-msvc': 4.57.1
-      '@rollup/rollup-win32-ia32-msvc': 4.57.1
-      '@rollup/rollup-win32-x64-gnu': 4.57.1
-      '@rollup/rollup-win32-x64-msvc': 4.57.1
-      fsevents: 2.3.3
-    optional: true
-
   rou3@0.8.1: {}
 
   run-parallel@1.2.0:
@@ -11009,15 +10523,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  seroval-plugins@1.3.3(seroval@1.3.2):
-    dependencies:
-      seroval: 1.3.2
-
   seroval-plugins@1.5.5(seroval@1.5.5):
     dependencies:
       seroval: 1.5.5
-
-  seroval@1.3.2: {}
 
   seroval@1.5.5: {}
 
@@ -11135,11 +10643,11 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  solid-js@1.9.10:
+  solid-js@1.9.14:
     dependencies:
       csstype: 3.2.3
-      seroval: 1.3.2
-      seroval-plugins: 1.3.3(seroval@1.3.2)
+      seroval: 1.5.5
+      seroval-plugins: 1.5.5(seroval@1.5.5)
 
   sonner@2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -11395,15 +10903,13 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+  unplugin@3.3.0(rolldown@1.1.5)(vite@8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
-      esbuild: 0.28.1
       rolldown: 1.1.5
-      rollup: 4.57.1
       vite: 8.1.4(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   update-browserslist-db@1.2.3(browserslist@4.28.6):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,11 @@ allowBuilds:
 
 trustPolicyExclude:
   - semver@6.3.1
+
+overrides:
+  brace-expansion@1.1.12: 1.1.13
+  esbuild@0.18.20: 0.25.12
+  minimatch@3.1.2: 3.1.4
+  picomatch@2.3.1: 2.3.2
+  rollup: 4.62.2
+  solid-js: 1.9.14

--- a/src/components/LazyImage.tsx
+++ b/src/components/LazyImage.tsx
@@ -2,34 +2,33 @@ import { AlertCircle, RefreshCw } from 'lucide-react'
 import { memo, useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
-import { useIntersectionObserver } from '@/features/dashboard/hooks/useIntersectionObserver'
+import { useIntersectionObserver } from '@/hooks/useIntersectionObserver'
 import { cn } from '@/lib/utils'
-
-const THUMBNAIL_SIZE = 48
 
 interface LazyImageProps {
   src: string
   alt: string
   className?: string
   rootMargin?: string
+  width?: number
+  height?: number
 }
 
-/**
- * Renders a lazy thumbnail with near-viewport eager loading, skeleton, and retry fallback.
- */
+/** Mounts image bytes only near the viewport and unloads them after exit. */
 export const LazyImage = memo(({
   src,
   alt,
   className,
   rootMargin = '0px',
+  width = 48,
+  height = 48,
 }: LazyImageProps) => {
   const [retryToken, setRetryToken] = useState(0)
   const [loadedSrc, setLoadedSrc] = useState<string | null>(null)
   const [failedSrc, setFailedSrc] = useState<string | null>(null)
   const { setNode, isIntersecting } = useIntersectionObserver<HTMLDivElement>({
     rootMargin,
-    // Thumbnails must be removed after leaving the viewport. Keeping every
-    // decoded source image mounted grows memory with each row the user sees.
+    // Unmount decoded pixels when a row leaves the viewport.
     freezeOnceVisible: false,
   })
 
@@ -56,9 +55,7 @@ export const LazyImage = memo(({
           size="icon"
           variant="ghost"
           className="absolute right-0.5 bottom-0.5 h-5 w-5"
-          onClick={() => {
-            setRetryToken(previous => previous + 1)
-          }}
+          onClick={() => setRetryToken(previous => previous + 1)}
           aria-label={`Retry loading ${alt}`}
         >
           <RefreshCw className="h-3 w-3" />
@@ -73,19 +70,15 @@ export const LazyImage = memo(({
         <img
           src={resolvedSrc}
           alt={alt}
-          width={THUMBNAIL_SIZE}
-          height={THUMBNAIL_SIZE}
+          width={width}
+          height={height}
           className={cn(
             'h-full w-full object-cover transition-opacity duration-150',
             isLoaded ? 'opacity-100' : 'opacity-0',
           )}
           decoding="async"
-          onLoad={() => {
-            setLoadedSrc(resolvedSrc)
-          }}
-          onError={() => {
-            setFailedSrc(resolvedSrc)
-          }}
+          onLoad={() => setLoadedSrc(resolvedSrc)}
+          onError={() => setFailedSrc(resolvedSrc)}
         />
       )}
       {!isLoaded && (

--- a/src/features/dashboard/components/DashboardFeature.tsx
+++ b/src/features/dashboard/components/DashboardFeature.tsx
@@ -12,6 +12,7 @@ import { DashboardLayout } from '@/features/dashboard/components/DashboardLayout
 import { DashboardTopbar } from '@/features/dashboard/components/DashboardTopbar'
 import { ImagesTable } from '@/features/dashboard/components/ImagesTable'
 import { SidebarAlbums } from '@/features/dashboard/components/SidebarAlbums'
+import { ThumbnailMaintenance } from '@/features/dashboard/components/ThumbnailMaintenance'
 import { UsageSummary } from '@/features/dashboard/components/UsageSummary'
 import { AlbumDialogs } from '@/features/dashboard/dialogs/AlbumDialogs'
 import { BulkMoveImagesDialog } from '@/features/dashboard/dialogs/BulkMoveImagesDialog'
@@ -176,6 +177,12 @@ export function DashboardFeature() {
       mobileSidebarOpen={mobileSidebarOpen}
       onMobileSidebarOpenChange={setMobileSidebarOpen}
     >
+      <ThumbnailMaintenance
+        onUpdated={() => {
+          retryImages()
+          void reloadAlbums()
+        }}
+      />
       <Card>
         <CardHeader className="space-y-3">
           <div className="flex flex-wrap items-center justify-between gap-3">

--- a/src/features/dashboard/components/ThumbnailMaintenance.tsx
+++ b/src/features/dashboard/components/ThumbnailMaintenance.tsx
@@ -1,0 +1,95 @@
+import { ImageDown, Pause } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Progress } from '@/components/ui/progress'
+import { useThumbnailMaintenance } from '@/features/dashboard/hooks/useThumbnailMaintenance'
+
+interface ThumbnailMaintenanceProps {
+  onUpdated: () => void
+}
+
+/** Presents the opt-in, resumable migration for legacy album previews. */
+export function ThumbnailMaintenance({ onUpdated }: ThumbnailMaintenanceProps) {
+  const maintenance = useThumbnailMaintenance(onUpdated)
+
+  if (maintenance.state === 'loading' || (maintenance.missingCount === 0 && maintenance.error === null)) {
+    return null
+  }
+
+  if (maintenance.error !== null && maintenance.missingCount === 0) {
+    return (
+      <Card>
+        <CardContent className="flex flex-wrap items-center justify-between gap-3 py-4">
+          <p role="alert" className="text-sm text-destructive">
+            Thumbnail maintenance is unavailable:
+            {' '}
+            {maintenance.error}
+          </p>
+          <Button type="button" size="sm" variant="outline" onClick={() => void maintenance.refresh()}>
+            Retry
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const isRunning = maintenance.state === 'running'
+  const progressValue = maintenance.progress === null || maintenance.progress.total === 0
+    ? 0
+    : (maintenance.progress.processed / maintenance.progress.total) * 100
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 py-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex min-w-0 items-start gap-3">
+            <ImageDown className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium">Generate faster album previews</p>
+              <p className="text-sm text-muted-foreground">
+                {maintenance.missingCount}
+                {' '}
+                legacy image(s) still use the full hosted file in albums. This runs locally and can be resumed.
+              </p>
+            </div>
+          </div>
+          {isRunning
+            ? (
+                <Button type="button" size="sm" variant="outline" onClick={maintenance.cancel}>
+                  <Pause className="mr-2 h-4 w-4" />
+                  Pause
+                </Button>
+              )
+            : (
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={() => void maintenance.start()}
+                >
+                  {maintenance.progress === null ? 'Start' : 'Resume'}
+                </Button>
+              )}
+        </div>
+
+        {maintenance.progress !== null && (
+          <div role="status" aria-live="polite" className="space-y-1.5">
+            <div className="flex flex-wrap justify-between gap-2 text-xs text-muted-foreground">
+              <span>
+                {maintenance.progress.processed}
+                {' / '}
+                {maintenance.progress.total}
+                {' processed'}
+                {maintenance.progress.failed > 0 && ` · ${maintenance.progress.failed} failed`}
+              </span>
+              <span className="max-w-64 truncate">{maintenance.progress.currentName}</span>
+            </div>
+            <Progress value={progressValue} />
+          </div>
+        )}
+        {maintenance.error !== null && (
+          <p role="alert" className="text-sm text-destructive">{maintenance.error}</p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/features/dashboard/components/ThumbnailMaintenance.tsx
+++ b/src/features/dashboard/components/ThumbnailMaintenance.tsx
@@ -1,4 +1,4 @@
-import { ImageDown, Pause } from 'lucide-react'
+import { ImageDown, LoaderCircle, Pause } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Progress } from '@/components/ui/progress'
@@ -34,6 +34,7 @@ export function ThumbnailMaintenance({ onUpdated }: ThumbnailMaintenanceProps) {
   }
 
   const isRunning = maintenance.state === 'running'
+  const isPausing = maintenance.state === 'pausing'
   const progressValue = maintenance.progress === null || maintenance.progress.total === 0
     ? 0
     : (maintenance.progress.processed / maintenance.progress.total) * 100
@@ -60,15 +61,22 @@ export function ThumbnailMaintenance({ onUpdated }: ThumbnailMaintenanceProps) {
                   Pause
                 </Button>
               )
-            : (
-                <Button
-                  type="button"
-                  size="sm"
-                  onClick={() => void maintenance.start()}
-                >
-                  {maintenance.progress === null ? 'Start' : 'Resume'}
-                </Button>
-              )}
+            : isPausing
+              ? (
+                  <Button type="button" size="sm" variant="outline" disabled>
+                    <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+                    Pausing…
+                  </Button>
+                )
+              : (
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => void maintenance.start()}
+                  >
+                    {maintenance.progress === null ? 'Start' : 'Resume'}
+                  </Button>
+                )}
         </div>
 
         {maintenance.progress !== null && (

--- a/src/features/dashboard/hooks/useImagesTable.tsx
+++ b/src/features/dashboard/hooks/useImagesTable.tsx
@@ -10,9 +10,9 @@ import {
   useReactTable,
 } from '@tanstack/react-table'
 import { useCallback, useMemo, useRef, useState } from 'react'
+import { LazyImage } from '@/components/LazyImage'
 import { Checkbox } from '@/components/ui/checkbox'
 import { ImageActionsDropdownMenu } from '@/features/dashboard/components/ImageActionsMenu'
-import { LazyImage } from '@/features/dashboard/components/LazyImage'
 import { applyShiftRangeSelection } from '@/features/dashboard/lib/shiftRangeSelection'
 import { formatBytes } from '@/lib/storage/format'
 

--- a/src/features/dashboard/hooks/useThumbnailMaintenance.ts
+++ b/src/features/dashboard/hooks/useThumbnailMaintenance.ts
@@ -65,6 +65,7 @@ export function useThumbnailMaintenance(onUpdated: () => void) {
   const [error, setError] = useState<string | null>(null)
   const [progress, setProgress] = useState<ThumbnailMaintenanceProgress | null>(null)
   const runningRef = useRef(false)
+  const generationRef = useRef(0)
   const abortRef = useRef<AbortController | null>(null)
   const mountedRef = useRef(true)
 
@@ -94,23 +95,30 @@ export function useThumbnailMaintenance(onUpdated: () => void) {
     return () => {
       mountedRef.current = false
       runningRef.current = false
+      generationRef.current += 1
       abortRef.current?.abort()
     }
   }, [refresh])
 
   const cancel = useCallback(() => {
     runningRef.current = false
+    generationRef.current += 1
     abortRef.current?.abort()
     abortRef.current = null
     setState('idle')
     setProgress(previous => previous === null ? null : { ...previous, currentName: null })
-  }, [])
+    onUpdated()
+    void refresh()
+  }, [onUpdated, refresh])
 
   const start = useCallback(async () => {
     if (runningRef.current) {
       return
     }
     runningRef.current = true
+    const generation = generationRef.current + 1
+    generationRef.current = generation
+    const isCurrentRun = () => runningRef.current && generationRef.current === generation
     setState('running')
     setError(null)
     const controller = new AbortController()
@@ -129,7 +137,7 @@ export function useThumbnailMaintenance(onUpdated: () => void) {
         setProgress({ total, processed, succeeded, failed, currentName: null })
 
         for (const candidate of page.items) {
-          if (!runningRef.current) {
+          if (!isCurrentRun()) {
             break
           }
           let didFinishCandidate = false
@@ -151,7 +159,7 @@ export function useThumbnailMaintenance(onUpdated: () => void) {
               type: sourceBlob.type || candidate.mime,
             })
             const thumbnail = await generateImageThumbnail(sourceFile)
-            if (!runningRef.current) {
+            if (!isCurrentRun()) {
               break
             }
 
@@ -175,7 +183,7 @@ export function useThumbnailMaintenance(onUpdated: () => void) {
             console.error(`[thumbnail-maintenance] Failed ${candidate.objectKey}:`, cause)
           }
           finally {
-            if (didFinishCandidate) {
+            if (didFinishCandidate && generationRef.current === generation) {
               processed += 1
               setProgress({ total, processed, succeeded, failed, currentName: null })
             }
@@ -183,34 +191,38 @@ export function useThumbnailMaintenance(onUpdated: () => void) {
         }
 
         cursor = page.nextCursor
-      } while (runningRef.current && cursor !== null)
+      } while (isCurrentRun() && cursor !== null)
     }
     catch (cause) {
-      if (!controller.signal.aborted) {
+      if (!controller.signal.aborted && generationRef.current === generation) {
         setError(errorMessage(cause))
       }
     }
     finally {
-      runningRef.current = false
-      abortRef.current = null
-      if (mountedRef.current) {
-        if (succeeded > 0) {
-          onUpdated()
-        }
-        try {
-          const summary = await loadMaintenancePage({ pageSize: 1 })
-          if (mountedRef.current) {
-            setMissingCount(summary.missingCount)
-          }
-        }
-        catch (cause) {
-          if (mountedRef.current) {
-            setError(errorMessage(cause))
-          }
+      if (generationRef.current === generation) {
+        runningRef.current = false
+        if (abortRef.current === controller) {
+          abortRef.current = null
         }
         if (mountedRef.current) {
-          setProgress(previous => previous === null ? null : { ...previous, currentName: null })
-          setState('idle')
+          if (succeeded > 0) {
+            onUpdated()
+          }
+          try {
+            const summary = await loadMaintenancePage({ pageSize: 1 })
+            if (mountedRef.current) {
+              setMissingCount(summary.missingCount)
+            }
+          }
+          catch (cause) {
+            if (mountedRef.current) {
+              setError(errorMessage(cause))
+            }
+          }
+          if (mountedRef.current) {
+            setProgress(previous => previous === null ? null : { ...previous, currentName: null })
+            setState('idle')
+          }
         }
       }
     }

--- a/src/features/dashboard/hooks/useThumbnailMaintenance.ts
+++ b/src/features/dashboard/hooks/useThumbnailMaintenance.ts
@@ -1,0 +1,214 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { z } from 'zod'
+import {
+  listMissingThumbnailsFn,
+  persistMissingThumbnailFn,
+} from '@/functions/thumbnails'
+import { generateImageThumbnail } from '@/lib/img'
+
+const MAINTENANCE_PAGE_SIZE = 8
+
+const maintenancePageSchema = z.object({
+  items: z.array(z.object({
+    objectKey: z.string(),
+    storedName: z.string(),
+    mime: z.string(),
+    publicUrl: z.string().url(),
+  })),
+  missingCount: z.number().int().nonnegative(),
+  nextCursor: z.string().nullable(),
+})
+
+async function loadMaintenancePage(input: {
+  cursor?: string | null
+  pageSize: number
+}): Promise<z.infer<typeof maintenancePageSchema>> {
+  const result: unknown = await listMissingThumbnailsFn({ data: input })
+  return maintenancePageSchema.parse(result)
+}
+
+export interface ThumbnailMaintenanceProgress {
+  total: number
+  processed: number
+  succeeded: number
+  failed: number
+  currentName: string | null
+}
+
+type MaintenanceState = 'loading' | 'idle' | 'running' | 'error'
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/** Runs the resumable, browser-side thumbnail migration one image at a time. */
+export function useThumbnailMaintenance(onUpdated: () => void) {
+  const [state, setState] = useState<MaintenanceState>('loading')
+  const [missingCount, setMissingCount] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+  const [progress, setProgress] = useState<ThumbnailMaintenanceProgress | null>(null)
+  const runningRef = useRef(false)
+  const abortRef = useRef<AbortController | null>(null)
+  const mountedRef = useRef(true)
+
+  const refresh = useCallback(async () => {
+    setState('loading')
+    setError(null)
+    try {
+      const page = await loadMaintenancePage({ pageSize: 1 })
+      if (!mountedRef.current) {
+        return
+      }
+      setMissingCount(page.missingCount)
+      setState('idle')
+    }
+    catch (cause) {
+      if (!mountedRef.current) {
+        return
+      }
+      setError(errorMessage(cause))
+      setState('error')
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    void refresh()
+    return () => {
+      mountedRef.current = false
+      runningRef.current = false
+      abortRef.current?.abort()
+    }
+  }, [refresh])
+
+  const cancel = useCallback(() => {
+    runningRef.current = false
+    abortRef.current?.abort()
+    abortRef.current = null
+    setState('idle')
+    setProgress(previous => previous === null ? null : { ...previous, currentName: null })
+  }, [])
+
+  const start = useCallback(async () => {
+    if (runningRef.current) {
+      return
+    }
+    runningRef.current = true
+    setState('running')
+    setError(null)
+    const controller = new AbortController()
+    abortRef.current = controller
+    let cursor: string | null = null
+    let processed = 0
+    let succeeded = 0
+    let failed = 0
+    let total = missingCount
+    setProgress({ total, processed, succeeded, failed, currentName: null })
+
+    try {
+      do {
+        const page = await loadMaintenancePage({ cursor, pageSize: MAINTENANCE_PAGE_SIZE })
+        total = Math.max(total, page.missingCount)
+        setProgress({ total, processed, succeeded, failed, currentName: null })
+
+        for (const candidate of page.items) {
+          if (!runningRef.current) {
+            break
+          }
+          let didFinishCandidate = false
+          setProgress({
+            total,
+            processed,
+            succeeded,
+            failed,
+            currentName: candidate.storedName,
+          })
+
+          try {
+            const response = await fetch(candidate.publicUrl, {
+              mode: 'cors',
+              signal: controller.signal,
+            })
+            if (!response.ok) {
+              throw new Error(`Image download failed (${response.status})`)
+            }
+            const sourceBlob = await response.blob()
+            const sourceFile = new File([sourceBlob], candidate.storedName, {
+              type: sourceBlob.type || candidate.mime,
+            })
+            const thumbnail = await generateImageThumbnail(sourceFile)
+            if (!runningRef.current) {
+              break
+            }
+
+            const formData = new FormData()
+            formData.set('objectKey', candidate.objectKey)
+            formData.set('thumbnail', new File(
+              [thumbnail.blob],
+              `${candidate.storedName}.thumbnail.webp`,
+              { type: 'image/webp' },
+            ))
+            await persistMissingThumbnailFn({ data: formData })
+            succeeded += 1
+            didFinishCandidate = true
+          }
+          catch (cause) {
+            if (controller.signal.aborted) {
+              break
+            }
+            failed += 1
+            didFinishCandidate = true
+            console.error(`[thumbnail-maintenance] Failed ${candidate.objectKey}:`, cause)
+          }
+          finally {
+            if (didFinishCandidate) {
+              processed += 1
+              setProgress({ total, processed, succeeded, failed, currentName: null })
+            }
+          }
+        }
+
+        cursor = page.nextCursor
+      } while (runningRef.current && cursor !== null)
+    }
+    catch (cause) {
+      if (!controller.signal.aborted) {
+        setError(errorMessage(cause))
+      }
+    }
+    finally {
+      runningRef.current = false
+      abortRef.current = null
+      if (mountedRef.current) {
+        if (succeeded > 0) {
+          onUpdated()
+        }
+        try {
+          const summary = await loadMaintenancePage({ pageSize: 1 })
+          if (mountedRef.current) {
+            setMissingCount(summary.missingCount)
+          }
+        }
+        catch (cause) {
+          if (mountedRef.current) {
+            setError(errorMessage(cause))
+          }
+        }
+        if (mountedRef.current) {
+          setProgress(previous => previous === null ? null : { ...previous, currentName: null })
+          setState('idle')
+        }
+      }
+    }
+  }, [missingCount, onUpdated])
+
+  return {
+    state,
+    missingCount,
+    progress,
+    error,
+    start,
+    cancel,
+    refresh,
+  }
+}

--- a/src/features/dashboard/hooks/useThumbnailMaintenance.ts
+++ b/src/features/dashboard/hooks/useThumbnailMaintenance.ts
@@ -35,7 +35,7 @@ export interface ThumbnailMaintenanceProgress {
   currentName: string | null
 }
 
-type MaintenanceState = 'loading' | 'idle' | 'running' | 'error'
+type MaintenanceState = 'loading' | 'idle' | 'running' | 'pausing' | 'error'
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
@@ -65,6 +65,7 @@ export function useThumbnailMaintenance(onUpdated: () => void) {
   const [error, setError] = useState<string | null>(null)
   const [progress, setProgress] = useState<ThumbnailMaintenanceProgress | null>(null)
   const runningRef = useRef(false)
+  const settlingRef = useRef(false)
   const generationRef = useRef(0)
   const abortRef = useRef<AbortController | null>(null)
   const mountedRef = useRef(true)
@@ -101,21 +102,22 @@ export function useThumbnailMaintenance(onUpdated: () => void) {
   }, [refresh])
 
   const cancel = useCallback(() => {
+    if (!runningRef.current) {
+      return
+    }
     runningRef.current = false
     generationRef.current += 1
     abortRef.current?.abort()
-    abortRef.current = null
-    setState('idle')
+    setState('pausing')
     setProgress(previous => previous === null ? null : { ...previous, currentName: null })
-    onUpdated()
-    void refresh()
-  }, [onUpdated, refresh])
+  }, [])
 
   const start = useCallback(async () => {
-    if (runningRef.current) {
+    if (runningRef.current || settlingRef.current) {
       return
     }
     runningRef.current = true
+    settlingRef.current = true
     const generation = generationRef.current + 1
     generationRef.current = generation
     const isCurrentRun = () => runningRef.current && generationRef.current === generation
@@ -199,11 +201,9 @@ export function useThumbnailMaintenance(onUpdated: () => void) {
       }
     }
     finally {
+      const ownsController = abortRef.current === controller
       if (generationRef.current === generation) {
         runningRef.current = false
-        if (abortRef.current === controller) {
-          abortRef.current = null
-        }
         if (mountedRef.current) {
           if (succeeded > 0) {
             onUpdated()
@@ -225,8 +225,18 @@ export function useThumbnailMaintenance(onUpdated: () => void) {
           }
         }
       }
+      else if (mountedRef.current && ownsController) {
+        if (succeeded > 0) {
+          onUpdated()
+        }
+        await refresh()
+      }
+      if (ownsController) {
+        abortRef.current = null
+        settlingRef.current = false
+      }
     }
-  }, [missingCount, onUpdated])
+  }, [missingCount, onUpdated, refresh])
 
   return {
     state,

--- a/src/features/dashboard/hooks/useThumbnailMaintenance.ts
+++ b/src/features/dashboard/hooks/useThumbnailMaintenance.ts
@@ -41,6 +41,23 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+async function fetchThumbnailSource(publicUrl: string, signal: AbortSignal) {
+  try {
+    return await fetch(publicUrl, { mode: 'cors', signal })
+  }
+  catch (cause) {
+    if (signal.aborted) {
+      throw cause
+    }
+
+    // A previously failed cross-origin response can remain in the browser cache.
+    // Retry once with a unique URL so one stale entry cannot block the migration.
+    const retryUrl = new URL(publicUrl)
+    retryUrl.searchParams.set('_thumbnailBackfill', Date.now().toString())
+    return fetch(retryUrl, { cache: 'reload', mode: 'cors', signal })
+  }
+}
+
 /** Runs the resumable, browser-side thumbnail migration one image at a time. */
 export function useThumbnailMaintenance(onUpdated: () => void) {
   const [state, setState] = useState<MaintenanceState>('loading')
@@ -125,10 +142,7 @@ export function useThumbnailMaintenance(onUpdated: () => void) {
           })
 
           try {
-            const response = await fetch(candidate.publicUrl, {
-              mode: 'cors',
-              signal: controller.signal,
-            })
+            const response = await fetchThumbnailSource(candidate.publicUrl, controller.signal)
             if (!response.ok) {
               throw new Error(`Image download failed (${response.status})`)
             }

--- a/src/features/home/ImageUploadArea.tsx
+++ b/src/features/home/ImageUploadArea.tsx
@@ -2,6 +2,8 @@ import { ImageIcon } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
 import { useDropzone } from 'react-dropzone'
 import { Card } from '@/components/ui/card'
+import { MAX_QUEUE_ITEMS, MAX_QUEUE_SOURCE_BYTES } from '@/features/home/lib/memoryBudget'
+import { getHumanReadableFileSize } from '@/utils/converter'
 
 interface ImageUploadAreaProps {
   onDrop: (files: File[]) => void
@@ -70,6 +72,14 @@ const ImageUploadArea = ({ onDrop, disabled = false }: ImageUploadAreaProps) => 
           {isDragActive
             ? 'Drop the images here'
             : 'Drag and drop images here, or click to select files'}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Up to
+          {' '}
+          {MAX_QUEUE_ITEMS}
+          {' images or '}
+          {getHumanReadableFileSize(MAX_QUEUE_SOURCE_BYTES)}
+          {' per queue'}
         </p>
       </div>
     </Card>

--- a/src/features/home/components/ResultRow.tsx
+++ b/src/features/home/components/ResultRow.tsx
@@ -1,5 +1,6 @@
 import type { HomeProcessedItem } from '@/features/home/types'
 import { AlertCircle, ArrowRight, Download, RotateCcw, Trash2 } from 'lucide-react'
+import { LazyImage } from '@/components/LazyImage'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -95,13 +96,14 @@ export function ResultRow({
           </div>
         )}
 
-        <div className="h-16 w-16 shrink-0 overflow-hidden rounded-lg sm:h-20 sm:w-20">
-          <img
-            src={item.thumbnailPreviewUrl ?? item.originalPreviewUrl}
-            alt={`Preview of ${item.originalName}`}
-            className="h-full w-full object-cover"
-          />
-        </div>
+        <LazyImage
+          src={item.thumbnailPreviewUrl ?? item.originalPreviewUrl}
+          alt={`Preview of ${item.originalName}`}
+          className="h-16 w-16 shrink-0 rounded-lg sm:h-20 sm:w-20"
+          rootMargin="200px 0px"
+          width={80}
+          height={80}
+        />
 
         <div className="min-w-0 flex-1 space-y-2">
           <div className="flex min-w-0 flex-wrap items-start justify-between gap-2 sm:flex-nowrap">

--- a/src/features/home/hooks/useCompressedDownloads.ts
+++ b/src/features/home/hooks/useCompressedDownloads.ts
@@ -1,7 +1,9 @@
 import type { HomeProcessedItem } from '@/features/home/types'
 import JSZip from 'jszip'
-import { useCallback, useTransition } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
+import { getZipInputBytes, MAX_ZIP_INPUT_BYTES } from '@/features/home/lib/memoryBudget'
+import { getHumanReadableFileSize } from '@/utils/converter'
 
 /**
  * Provides single-file and zip download actions for processed home rows.
@@ -10,7 +12,8 @@ import { toast } from 'sonner'
  * @returns Pending state and callbacks for download actions.
  */
 export function useCompressedDownloads(items: readonly HomeProcessedItem[]) {
-  const [downloadingAll, startDownloadingAll] = useTransition()
+  const [downloadingAll, setDownloadingAll] = useState(false)
+  const downloadingAllRef = useRef(false)
 
   const downloadOne = useCallback((item: HomeProcessedItem) => {
     if (item.outputFile === null) {
@@ -30,33 +33,56 @@ export function useCompressedDownloads(items: readonly HomeProcessedItem[]) {
   }, [])
 
   const downloadAll = useCallback(() => {
-    startDownloadingAll(async () => {
-      const transformed = items.filter(item => item.outputFile !== null)
-      if (transformed.length === 0) {
-        toast.error('No processed images available to download')
-        return
-      }
+    if (downloadingAllRef.current) {
+      return
+    }
+    downloadingAllRef.current = true
+    setDownloadingAll(true)
 
-      const zip = new JSZip()
-      for (const item of transformed) {
-        if (!item.outputFile) {
-          continue
+    void (async () => {
+      try {
+        const transformed = items.filter(item => item.outputFile !== null)
+        if (transformed.length === 0) {
+          toast.error('No processed images available to download')
+          return
         }
-        zip.file(item.outputFile.name, item.outputFile)
-      }
 
-      const zipBlob = await zip.generateAsync({ type: 'blob' })
-      const url = URL.createObjectURL(zipBlob)
-      const link = document.createElement('a')
-      link.href = url
-      link.download = `images-${new Date().toISOString().slice(0, 10)}.zip`
-      document.body.appendChild(link)
-      link.click()
-      document.body.removeChild(link)
-      URL.revokeObjectURL(url)
-      toast.success('Downloaded processed image zip')
-    })
-  }, [items, startDownloadingAll])
+        const outputFiles = transformed.flatMap(item => item.outputFile === null ? [] : [item.outputFile])
+        const zipInputBytes = getZipInputBytes(outputFiles)
+        if (zipInputBytes > MAX_ZIP_INPUT_BYTES) {
+          toast.error('Batch is too large to zip safely in this browser tab', {
+            description: `${getHumanReadableFileSize(zipInputBytes)} exceeds the ${getHumanReadableFileSize(MAX_ZIP_INPUT_BYTES)} ZIP memory guard. Download files individually instead.`,
+          })
+          return
+        }
+
+        const zip = new JSZip()
+        for (const file of outputFiles) {
+          zip.file(file.name, file)
+        }
+
+        const zipBlob = await zip.generateAsync({ type: 'blob', compression: 'STORE', streamFiles: true })
+        const url = URL.createObjectURL(zipBlob)
+        const link = document.createElement('a')
+        link.href = url
+        link.download = `images-${new Date().toISOString().slice(0, 10)}.zip`
+        document.body.appendChild(link)
+        link.click()
+        document.body.removeChild(link)
+        URL.revokeObjectURL(url)
+        toast.success('Downloaded processed image zip')
+      }
+      catch (error) {
+        toast.error('Could not prepare the image zip', {
+          description: error instanceof Error ? error.message : String(error),
+        })
+      }
+      finally {
+        downloadingAllRef.current = false
+        setDownloadingAll(false)
+      }
+    })()
+  }, [items])
 
   return {
     downloadingAll,

--- a/src/features/home/hooks/useImageTransformQueue.ts
+++ b/src/features/home/hooks/useImageTransformQueue.ts
@@ -2,8 +2,14 @@ import type { CompressionState, HomeProcessedItem } from '@/features/home/types'
 import { nanoid } from 'nanoid'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
+import {
+  MAX_QUEUE_ITEMS,
+  MAX_QUEUE_SOURCE_BYTES,
+  selectWithinQueueBudget,
+} from '@/features/home/lib/memoryBudget'
 import { checkImage, normalizeTransformError, transformImageFile } from '@/lib/img'
 import { normalizeImageMime } from '@/lib/storage/format'
+import { getHumanReadableFileSize } from '@/utils/converter'
 
 function fileBaseName(name: string): string {
   const value = name.split('.').slice(0, -1).join('.').trim()
@@ -48,6 +54,7 @@ export function useImageTransformQueue() {
   const [isTransforming, setIsTransforming] = useState(false)
   const itemsRef = useRef<HomeProcessedItem[]>([])
   const isTransformingRef = useRef(false)
+  const queueSourceBytesRef = useRef(0)
 
   useEffect(() => {
     itemsRef.current = items
@@ -69,43 +76,12 @@ export function useImageTransformQueue() {
   }, [])
 
   const addImages = useCallback((files: File[]) => {
-    const accepted: HomeProcessedItem[] = []
+    const validFiles: Array<{ file: File, format: SupportedFormat, name: string, originalSize: number, size: number }> = []
 
     for (const file of files) {
       try {
         const { format, name, originalSize } = checkImage(file)
-        accepted.push({
-          id: nanoid(8),
-          originalFile: file,
-          originalName: name,
-          originalSize,
-          originalPreviewUrl: URL.createObjectURL(file),
-          thumbnailPreviewUrl: null,
-          originalFormat: format,
-          targetFormat,
-          outputBlob: null,
-          outputFile: null,
-          outputSize: null,
-          width: null,
-          height: null,
-          sourceWidth: null,
-          sourceHeight: null,
-          thumbnailBlob: null,
-          thumbnailFile: null,
-          thumbnailSize: null,
-          thumbnailWidth: null,
-          thumbnailHeight: null,
-          retainOriginal,
-          status: 'idle',
-          transformError: null,
-          transformNotice: null,
-          uploadStatus: 'idle',
-          uploadError: null,
-          uploadedUrl: null,
-          uploadedObjectKey: null,
-          uploadedAlbumId: null,
-          selected: false,
-        })
+        validFiles.push({ file, format, name, originalSize, size: file.size })
       }
       catch (error) {
         toast.error('Skipped invalid image', {
@@ -114,23 +90,71 @@ export function useImageTransformQueue() {
       }
     }
 
+    const budget = selectWithinQueueBudget({
+      currentBytes: queueSourceBytesRef.current,
+      currentItems: itemsRef.current.length,
+      candidates: validFiles,
+    })
+    const accepted: HomeProcessedItem[] = budget.accepted.map(({ file, format, name, originalSize }) => ({
+      id: nanoid(8),
+      originalFile: file,
+      originalName: name,
+      originalSize,
+      originalPreviewUrl: URL.createObjectURL(file),
+      thumbnailPreviewUrl: null,
+      originalFormat: format,
+      targetFormat,
+      outputBlob: null,
+      outputFile: null,
+      outputSize: null,
+      width: null,
+      height: null,
+      sourceWidth: null,
+      sourceHeight: null,
+      thumbnailBlob: null,
+      thumbnailFile: null,
+      thumbnailSize: null,
+      thumbnailWidth: null,
+      thumbnailHeight: null,
+      retainOriginal,
+      status: 'idle',
+      transformError: null,
+      transformNotice: null,
+      uploadStatus: 'idle',
+      uploadError: null,
+      uploadedUrl: null,
+      uploadedObjectKey: null,
+      uploadedAlbumId: null,
+      selected: false,
+    }))
+
+    if (budget.rejected.length > 0) {
+      toast.warning(`${budget.rejected.length} image(s) were not added`, {
+        description: `One queue can hold up to ${MAX_QUEUE_ITEMS} images or ${getHumanReadableFileSize(MAX_QUEUE_SOURCE_BYTES)} of source files.`,
+      })
+    }
+
     if (accepted.length > 0) {
-      setItems(prev => [...prev, ...accepted])
+      queueSourceBytesRef.current = budget.totalBytes
+      const nextItems = [...itemsRef.current, ...accepted]
+      itemsRef.current = nextItems
+      setItems(nextItems)
       setCompressionState('idle')
     }
   }, [retainOriginal, targetFormat])
 
   const removeItem = useCallback((id: string) => {
-    setItems((prev) => {
-      const target = prev.find(item => item.id === id)
-      if (target) {
-        URL.revokeObjectURL(target.originalPreviewUrl)
-        if (target.thumbnailPreviewUrl !== null) {
-          URL.revokeObjectURL(target.thumbnailPreviewUrl)
-        }
+    const target = itemsRef.current.find(item => item.id === id)
+    if (target) {
+      queueSourceBytesRef.current = Math.max(0, queueSourceBytesRef.current - target.originalSize)
+      URL.revokeObjectURL(target.originalPreviewUrl)
+      if (target.thumbnailPreviewUrl !== null) {
+        URL.revokeObjectURL(target.thumbnailPreviewUrl)
       }
-      return prev.filter(item => item.id !== id)
-    })
+    }
+    const nextItems = itemsRef.current.filter(item => item.id !== id)
+    itemsRef.current = nextItems
+    setItems(nextItems)
   }, [])
 
   const transformOne = useCallback(async (item: HomeProcessedItem): Promise<HomeProcessedItem> => {

--- a/src/features/home/lib/memoryBudget.test.ts
+++ b/src/features/home/lib/memoryBudget.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getZipInputBytes,
+  MAX_QUEUE_ITEMS,
+  MAX_QUEUE_SOURCE_BYTES,
+  MAX_ZIP_INPUT_BYTES,
+  selectWithinQueueBudget,
+} from './memoryBudget'
+
+const MiB = 1024 * 1024
+
+describe('home memory budgets', () => {
+  it('accepts a representative 200-image, 85 MiB batch', () => {
+    const totalBytes = 85 * MiB
+    const perFileBytes = Math.floor(totalBytes / 200)
+    const candidates = Array.from({ length: 200 }, (_, id) => ({
+      id,
+      size: id === 199 ? totalBytes - perFileBytes * 199 : perFileBytes,
+    }))
+
+    const result = selectWithinQueueBudget({ currentBytes: 0, currentItems: 0, candidates })
+
+    expect(result.accepted).toHaveLength(MAX_QUEUE_ITEMS)
+    expect(result.rejected).toHaveLength(0)
+    expect(result.totalBytes).toBe(totalBytes)
+  })
+
+  it('continues admitting smaller files after one candidate exceeds the byte budget', () => {
+    const result = selectWithinQueueBudget({
+      currentBytes: MAX_QUEUE_SOURCE_BYTES - MiB,
+      currentItems: 1,
+      candidates: [
+        { id: 'large', size: 2 * MiB },
+        { id: 'small', size: MiB },
+      ],
+    })
+
+    expect(result.accepted.map(item => item.id)).toEqual(['small'])
+    expect(result.rejected.map(item => item.id)).toEqual(['large'])
+    expect(result.totalBytes).toBe(MAX_QUEUE_SOURCE_BYTES)
+  })
+
+  it('caps additional rows after the item limit', () => {
+    const result = selectWithinQueueBudget({
+      currentBytes: 0,
+      currentItems: MAX_QUEUE_ITEMS,
+      candidates: [{ size: 1 }],
+    })
+
+    expect(result.accepted).toHaveLength(0)
+    expect(result.rejected).toHaveLength(1)
+  })
+
+  it('calculates the aggregate ZIP duplication budget', () => {
+    expect(getZipInputBytes([{ size: MAX_ZIP_INPUT_BYTES - 1 }, { size: 1 }]))
+      .toBe(MAX_ZIP_INPUT_BYTES)
+  })
+})

--- a/src/features/home/lib/memoryBudget.ts
+++ b/src/features/home/lib/memoryBudget.ts
@@ -1,0 +1,49 @@
+/** Maximum source bytes retained by the in-browser transform queue. */
+export const MAX_QUEUE_SOURCE_BYTES = 256 * 1024 * 1024
+
+/** Maximum row count retained by the in-browser transform queue. */
+export const MAX_QUEUE_ITEMS = 200
+
+/** Largest aggregate output batch that may be duplicated into an in-memory ZIP. */
+export const MAX_ZIP_INPUT_BYTES = 128 * 1024 * 1024
+
+interface SizedValue {
+  size: number
+}
+
+export interface QueueBudgetResult<T> {
+  accepted: T[]
+  rejected: T[]
+  totalBytes: number
+  totalItems: number
+}
+
+/** Greedily admits files that fit both the queue byte and row budgets. */
+export function selectWithinQueueBudget<T extends SizedValue>(input: {
+  currentBytes: number
+  currentItems: number
+  candidates: readonly T[]
+}): QueueBudgetResult<T> {
+  let totalBytes = Math.max(0, input.currentBytes)
+  let totalItems = Math.max(0, input.currentItems)
+  const accepted: T[] = []
+  const rejected: T[] = []
+
+  for (const candidate of input.candidates) {
+    const nextBytes = totalBytes + Math.max(0, candidate.size)
+    if (totalItems >= MAX_QUEUE_ITEMS || nextBytes > MAX_QUEUE_SOURCE_BYTES) {
+      rejected.push(candidate)
+      continue
+    }
+    accepted.push(candidate)
+    totalItems += 1
+    totalBytes = nextBytes
+  }
+
+  return { accepted, rejected, totalBytes, totalItems }
+}
+
+/** Returns the aggregate bytes that JSZip would need to duplicate. */
+export function getZipInputBytes(files: readonly SizedValue[]): number {
+  return files.reduce((total, file) => total + Math.max(0, file.size), 0)
+}

--- a/src/functions/thumbnails.ts
+++ b/src/functions/thumbnails.ts
@@ -1,0 +1,74 @@
+import { createServerFn } from '@tanstack/react-start'
+import { z } from 'zod'
+import { requireAuth } from '@/lib/auth/guards'
+import { getD1Binding, getR2Binding } from '@/lib/cloudflare/bindings'
+import { buildPublicImageUrl, getR2PublicDomain } from '@/lib/cloudflare/publicUrl'
+import { validateUploadImage } from '@/lib/images/uploadValidation'
+import {
+  persistMissingThumbnail,
+} from '@/lib/storage/thumbnailMaintenance'
+import { listMissingThumbnailCandidates } from '@/lib/storage/thumbnailMaintenanceRepo'
+
+const listMissingThumbnailsSchema = z.object({
+  cursor: z.string().min(1).nullable().optional(),
+  pageSize: z.number().int().min(1).max(20).optional(),
+})
+
+const MAX_THUMBNAIL_UPLOAD_BYTES = 1024 * 1024
+
+function validateThumbnailPayload(input: unknown): FormData {
+  if (input instanceof FormData) {
+    return input
+  }
+  throw new Error('Invalid thumbnail payload')
+}
+
+/** Lists a bounded, resumable page of legacy images needing thumbnails. */
+export const listMissingThumbnailsFn = createServerFn({ method: 'POST' })
+  .validator(listMissingThumbnailsSchema)
+  .handler(async ({ data }) => {
+    await requireAuth()
+    const page = await listMissingThumbnailCandidates(getD1Binding(), data)
+    const publicDomain = getR2PublicDomain()
+    return {
+      ...page,
+      items: page.items.map(item => ({
+        objectKey: item.objectKey,
+        storedName: item.storedName,
+        mime: item.mime,
+        publicUrl: buildPublicImageUrl(item.objectKey, publicDomain),
+      })),
+    }
+  })
+
+/** Validates and stores one browser-generated legacy thumbnail. */
+export const persistMissingThumbnailFn = createServerFn({ method: 'POST' })
+  .validator(validateThumbnailPayload)
+  .handler(async ({ data }) => {
+    await requireAuth()
+    const objectKey = z.string().min(1).max(512).parse(data.get('objectKey'))
+    const thumbnailEntry = data.get('thumbnail')
+    if (!(thumbnailEntry instanceof File)) {
+      throw new TypeError('WebP thumbnail is required')
+    }
+    if (thumbnailEntry.size > MAX_THUMBNAIL_UPLOAD_BYTES) {
+      throw new Error('Thumbnail must not exceed 1 MiB')
+    }
+
+    const thumbnail = await validateUploadImage(thumbnailEntry)
+    if (thumbnail.mime !== 'image/webp') {
+      throw new Error('Thumbnail must be WebP')
+    }
+    if (thumbnail.width > 512 || thumbnail.height > 512) {
+      throw new Error('Thumbnail dimensions must not exceed 512 pixels')
+    }
+
+    return persistMissingThumbnail({
+      db: getD1Binding(),
+      r2: getR2Binding(),
+      objectKey,
+      bytes: thumbnail.bytes,
+      width: thumbnail.width,
+      height: thumbnail.height,
+    })
+  })

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -6,15 +6,7 @@ interface UseIntersectionObserverOptions {
   freezeOnceVisible?: boolean
 }
 
-/**
- * Tracks element visibility and supports near-viewport prefetch margins.
- *
- * @param options Observer options.
- * @param options.rootMargin Root margin passed to `IntersectionObserver`.
- * @param options.threshold Intersection threshold passed to `IntersectionObserver`.
- * @param options.freezeOnceVisible When true, observer stops after first intersection.
- * @returns Ref setter and latest intersection status.
- */
+/** Tracks whether an element is inside or near the current viewport. */
 export function useIntersectionObserver<T extends Element>(options: UseIntersectionObserverOptions = {}) {
   const {
     rootMargin = '500px 0px',
@@ -41,10 +33,7 @@ export function useIntersectionObserver<T extends Element>(options: UseIntersect
       ([entry]) => {
         setIsIntersecting(entry?.isIntersecting ?? false)
       },
-      {
-        rootMargin,
-        threshold,
-      },
+      { rootMargin, threshold },
     )
 
     observer.observe(node)
@@ -53,8 +42,5 @@ export function useIntersectionObserver<T extends Element>(options: UseIntersect
     }
   }, [freezeOnceVisible, isIntersecting, node, rootMargin, threshold])
 
-  return {
-    setNode,
-    isIntersecting,
-  }
+  return { setNode, isIntersecting }
 }

--- a/src/lib/img/index.ts
+++ b/src/lib/img/index.ts
@@ -1,2 +1,2 @@
 export { checkImage } from './checker'
-export { normalizeTransformError, transformImageFile } from './transform-client'
+export { generateImageThumbnail, normalizeTransformError, transformImageFile } from './transform-client'

--- a/src/lib/img/transform-client.test.ts
+++ b/src/lib/img/transform-client.test.ts
@@ -2,8 +2,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 interface WorkerRequest {
   id: number
+  mode: 'full' | 'thumbnail'
   file: File
-  format: SupportedFormat
+  format?: SupportedFormat
   quality?: number
 }
 
@@ -40,6 +41,7 @@ function workerResult(request: WorkerRequest, overrides: Record<string, unknown>
   return {
     id: request.id,
     result: {
+      mode: 'full',
       blob: new Blob(['hosted'], { type: 'image/webp' }),
       mimeType: 'image/webp',
       width: 640,
@@ -78,7 +80,7 @@ describe('transformImageFile', () => {
 
     const result = await transformImageFile(source, 'webp', 80)
 
-    expect(FakeWorker.lastRequest).toMatchObject({ file: source, format: 'webp', quality: 80 })
+    expect(FakeWorker.lastRequest).toMatchObject({ mode: 'full', file: source, format: 'webp', quality: 80 })
     expect(result).toMatchObject({
       mimeType: 'image/webp',
       width: 640,
@@ -112,6 +114,27 @@ describe('transformImageFile', () => {
     const source = new File(['source'], 'input.raw', { type: 'application/octet-stream' })
 
     await expect(transformImageFile(source, 'webp')).rejects.toThrow('Unsupported RAW camera')
+  })
+
+  it('requests only a WebP thumbnail for maintenance work', async () => {
+    FakeWorker.response = request => ({
+      id: request.id,
+      result: {
+        mode: 'thumbnail',
+        blob: new Blob(['thumbnail'], { type: 'image/webp' }),
+        width: 512,
+        height: 384,
+      },
+    })
+    const { generateImageThumbnail } = await loadTransformModule()
+    const source = new File(['source'], 'legacy.jpg', { type: 'image/jpeg' })
+
+    const result = await generateImageThumbnail(source)
+
+    expect(FakeWorker.lastRequest).toMatchObject({ mode: 'thumbnail', file: source })
+    expect(FakeWorker.lastRequest).not.toHaveProperty('format')
+    expect(result).toMatchObject({ width: 512, height: 384 })
+    expect(result.blob.type).toBe('image/webp')
   })
 
   it('terminates a stalled worker and rejects queued transforms', async () => {

--- a/src/lib/img/transform-client.ts
+++ b/src/lib/img/transform-client.ts
@@ -19,9 +19,25 @@ export interface TransformImageResult {
   sourceNotice: string | null
 }
 
-interface WorkerTransformResult extends Omit<TransformImageResult, 'blob'> {
+export interface TransformThumbnailResult {
+  blob: Blob
+  width: number
+  height: number
+}
+
+interface WorkerFullTransformResult extends Omit<TransformImageResult, 'blob'> {
+  mode: 'full'
   blob: Blob | null
 }
+
+interface WorkerThumbnailTransformResult {
+  mode: 'thumbnail'
+  blob: Blob
+  width: number
+  height: number
+}
+
+type WorkerTransformResult = WorkerFullTransformResult | WorkerThumbnailTransformResult
 
 interface TransformWorkerResponse {
   id: number
@@ -29,12 +45,22 @@ interface TransformWorkerResponse {
   error?: string
 }
 
-interface PendingTransform {
+interface PendingFullTransform {
+  mode: 'full'
   file: File
   resolve: (result: TransformImageResult) => void
   reject: (error: Error) => void
   timeoutId: ReturnType<typeof setTimeout>
 }
+
+interface PendingThumbnailTransform {
+  mode: 'thumbnail'
+  resolve: (result: TransformThumbnailResult) => void
+  reject: (error: Error) => void
+  timeoutId: ReturnType<typeof setTimeout>
+}
+
+type PendingTransform = PendingFullTransform | PendingThumbnailTransform
 
 let transformWorker: Worker | null = null
 let nextTransformId = 0
@@ -103,12 +129,23 @@ function getTransformWorker(): Worker {
       return
     }
 
-    pending.resolve({
-      ...event.data.result,
-      blob: event.data.result.preservedOriginal
-        ? pending.file
-        : (event.data.result.blob ?? pending.file),
-    })
+    const result = event.data.result
+    if (pending.mode === 'thumbnail' && result.mode === 'thumbnail') {
+      pending.resolve({ blob: result.blob, width: result.width, height: result.height })
+      scheduleWorkerTermination()
+      return
+    }
+    if (pending.mode === 'full' && result.mode === 'full') {
+      pending.resolve({
+        ...result,
+        blob: result.preservedOriginal
+          ? pending.file
+          : (result.blob ?? pending.file),
+      })
+      scheduleWorkerTermination()
+      return
+    }
+    pending.reject(new Error('Image worker returned a mismatched result'))
     scheduleWorkerTermination()
   })
 
@@ -144,15 +181,43 @@ export async function transformImageFile(
       transformWorker = null
       rejectPendingTransforms('Image transform timed out. Try a smaller or different source file.')
     }, TRANSFORM_TIMEOUT_MS)
-    pendingTransforms.set(id, { file, resolve, reject, timeoutId })
+    pendingTransforms.set(id, { mode: 'full', file, resolve, reject, timeoutId })
 
     try {
       getTransformWorker().postMessage({
         id,
+        mode: 'full',
         file,
         format,
         quality,
       })
+    }
+    catch (error) {
+      const pending = pendingTransforms.get(id)
+      if (pending !== undefined) {
+        clearTimeout(pending.timeoutId)
+        pendingTransforms.delete(id)
+      }
+      reject(error instanceof Error ? error : new Error(String(error)))
+    }
+  })
+}
+
+/** Generates only the album WebP thumbnail, skipping the full-size encode. */
+export async function generateImageThumbnail(file: File): Promise<TransformThumbnailResult> {
+  return new Promise((resolve, reject) => {
+    const id = nextTransformId
+    nextTransformId += 1
+    const timeoutId = setTimeout(() => {
+      clearWorkerIdleTimer()
+      transformWorker?.terminate()
+      transformWorker = null
+      rejectPendingTransforms('Image transform timed out. Try a smaller or different source file.')
+    }, TRANSFORM_TIMEOUT_MS)
+    pendingTransforms.set(id, { mode: 'thumbnail', resolve, reject, timeoutId })
+
+    try {
+      getTransformWorker().postMessage({ id, mode: 'thumbnail', file })
     }
     catch (error) {
       const pending = pendingTransforms.get(id)

--- a/src/lib/img/transform.worker.ts
+++ b/src/lib/img/transform.worker.ts
@@ -306,6 +306,9 @@ async function transformThumbnailOnly(file: File): Promise<{
 
   const probe = new Uint8Array(await file.slice(0, NATIVE_METADATA_PROBE_BYTES).arrayBuffer())
   const metadata = parseUploadImage(probe)
+    ?? (file.size > probe.byteLength
+      ? parseUploadImage(new Uint8Array(await file.arrayBuffer()))
+      : null)
   if (metadata === null) {
     throw new Error('Unable to read image dimensions for thumbnail generation')
   }

--- a/src/lib/img/transform.worker.ts
+++ b/src/lib/img/transform.worker.ts
@@ -28,12 +28,21 @@ const RAW_EXTENSIONS = new Set([
   'srf',
 ])
 
-interface TransformRequest {
+interface FullTransformRequest {
   id: number
+  mode: 'full'
   file: File
   format: SupportedFormat
   quality?: number
 }
+
+interface ThumbnailTransformRequest {
+  id: number
+  mode: 'thumbnail'
+  file: File
+}
+
+type TransformRequest = FullTransformRequest | ThumbnailTransformRequest
 
 interface DecodedSource {
   canvas: OffscreenCanvas
@@ -253,7 +262,10 @@ async function encodeCanvas(
   return new Blob([bytes], { type: mimeType })
 }
 
-async function transform(request: TransformRequest): Promise<Omit<TransformImageResult, 'blob'> & { blob: Blob | null }> {
+async function transform(request: TransformRequest): Promise<
+  | (Omit<TransformImageResult, 'blob'> & { mode: 'full', blob: Blob | null })
+  | { mode: 'thumbnail', blob: Blob, width: number, height: number }
+> {
   const decoded = await decodeSource(request.file)
   const thumbnailDimensions = outputDimensions(decoded.width, decoded.height, THUMBNAIL_MAX_EDGE)
   const thumbnailCanvas = new OffscreenCanvas(thumbnailDimensions.width, thumbnailDimensions.height)
@@ -265,11 +277,21 @@ async function transform(request: TransformRequest): Promise<Omit<TransformImage
     thumbnailContext.drawImage(decoded.canvas, 0, 0, thumbnailDimensions.width, thumbnailDimensions.height)
     const thumbnailBlob = await encodeCanvas(thumbnailCanvas, 'webp', 72)
 
+    if (request.mode === 'thumbnail') {
+      return {
+        mode: 'thumbnail',
+        blob: thumbnailBlob,
+        width: thumbnailDimensions.width,
+        height: thumbnailDimensions.height,
+      }
+    }
+
     const hostedBlob = decoded.preservedOriginal
       ? null
       : await encodeCanvas(decoded.canvas, request.format, request.quality)
 
     return {
+      mode: 'full',
       blob: hostedBlob,
       mimeType: decoded.preservedOriginal
         ? request.file.type

--- a/src/lib/img/transform.worker.ts
+++ b/src/lib/img/transform.worker.ts
@@ -28,6 +28,8 @@ const RAW_EXTENSIONS = new Set([
   'srf',
 ])
 
+const NATIVE_METADATA_PROBE_BYTES = 2 * 1024 * 1024
+
 interface FullTransformRequest {
   id: number
   mode: 'full'
@@ -233,6 +235,15 @@ function outputDimensions(width: number, height: number, maxEdge: number): { wid
   }
 }
 
+function requiresDedicatedDecoder(file: File): boolean {
+  const extension = extensionOf(file.name)
+  return extension === 'heic'
+    || extension === 'heif'
+    || extension === 'tif'
+    || extension === 'tiff'
+    || RAW_EXTENSIONS.has(extension)
+}
+
 async function encodeCanvas(
   canvas: OffscreenCanvas,
   format: SupportedFormat,
@@ -262,10 +273,78 @@ async function encodeCanvas(
   return new Blob([bytes], { type: mimeType })
 }
 
+async function transformThumbnailOnly(file: File): Promise<{
+  mode: 'thumbnail'
+  blob: Blob
+  width: number
+  height: number
+}> {
+  if (requiresDedicatedDecoder(file)) {
+    const decoded = await decodeSource(file)
+    const dimensions = outputDimensions(decoded.width, decoded.height, THUMBNAIL_MAX_EDGE)
+    const canvas = new OffscreenCanvas(dimensions.width, dimensions.height)
+    try {
+      const context = canvas.getContext('2d')
+      if (!context) {
+        throw new Error('Failed to initialize thumbnail canvas')
+      }
+      context.drawImage(decoded.canvas, 0, 0, dimensions.width, dimensions.height)
+      return {
+        mode: 'thumbnail',
+        blob: await encodeCanvas(canvas, 'webp', 72),
+        width: dimensions.width,
+        height: dimensions.height,
+      }
+    }
+    finally {
+      decoded.canvas.width = 1
+      decoded.canvas.height = 1
+      canvas.width = 1
+      canvas.height = 1
+    }
+  }
+
+  const probe = new Uint8Array(await file.slice(0, NATIVE_METADATA_PROBE_BYTES).arrayBuffer())
+  const metadata = parseUploadImage(probe)
+  if (metadata === null) {
+    throw new Error('Unable to read image dimensions for thumbnail generation')
+  }
+  const dimensions = outputDimensions(metadata.width, metadata.height, THUMBNAIL_MAX_EDGE)
+  const bitmap = await createImageBitmap(file, {
+    imageOrientation: 'from-image',
+    resizeWidth: dimensions.width,
+    resizeHeight: dimensions.height,
+    resizeQuality: 'high',
+  })
+  const canvas = new OffscreenCanvas(bitmap.width, bitmap.height)
+  try {
+    const context = canvas.getContext('2d')
+    if (!context) {
+      throw new Error('Failed to initialize thumbnail canvas')
+    }
+    context.drawImage(bitmap, 0, 0)
+    return {
+      mode: 'thumbnail',
+      blob: await encodeCanvas(canvas, 'webp', 72),
+      width: bitmap.width,
+      height: bitmap.height,
+    }
+  }
+  finally {
+    bitmap.close()
+    canvas.width = 1
+    canvas.height = 1
+  }
+}
+
 async function transform(request: TransformRequest): Promise<
   | (Omit<TransformImageResult, 'blob'> & { mode: 'full', blob: Blob | null })
   | { mode: 'thumbnail', blob: Blob, width: number, height: number }
 > {
+  if (request.mode === 'thumbnail') {
+    return transformThumbnailOnly(request.file)
+  }
+
   const decoded = await decodeSource(request.file)
   const thumbnailDimensions = outputDimensions(decoded.width, decoded.height, THUMBNAIL_MAX_EDGE)
   const thumbnailCanvas = new OffscreenCanvas(thumbnailDimensions.width, thumbnailDimensions.height)
@@ -276,15 +355,6 @@ async function transform(request: TransformRequest): Promise<
     }
     thumbnailContext.drawImage(decoded.canvas, 0, 0, thumbnailDimensions.width, thumbnailDimensions.height)
     const thumbnailBlob = await encodeCanvas(thumbnailCanvas, 'webp', 72)
-
-    if (request.mode === 'thumbnail') {
-      return {
-        mode: 'thumbnail',
-        blob: thumbnailBlob,
-        width: thumbnailDimensions.width,
-        height: thumbnailDimensions.height,
-      }
-    }
 
     const hostedBlob = decoded.preservedOriginal
       ? null

--- a/src/lib/storage/thumbnailMaintenance.test.ts
+++ b/src/lib/storage/thumbnailMaintenance.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getDb: vi.fn(),
+  buildThumbnailR2ObjectKey: vi.fn(() => 'thumbnails/2026/07/16/thumb.webp'),
+  putImageObject: vi.fn(),
+  cleanupUncommittedUpload: vi.fn(),
+  releaseStorageReservation: vi.fn(),
+}))
+
+vi.mock('@/lib/db/client', () => ({ getDb: mocks.getDb }))
+vi.mock('@/lib/storage/r2Repo', () => ({
+  buildThumbnailR2ObjectKey: mocks.buildThumbnailR2ObjectKey,
+  putImageObject: mocks.putImageObject,
+}))
+vi.mock('@/lib/storage/uploadReconciliation', () => ({
+  cleanupUncommittedUpload: mocks.cleanupUncommittedUpload,
+  releaseStorageReservation: mocks.releaseStorageReservation,
+}))
+
+function selectChain(result: unknown, rejection?: Error) {
+  const chain = {
+    from: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn(),
+  }
+  chain.from.mockReturnValue(chain)
+  chain.where.mockReturnValue(chain)
+  chain.limit.mockImplementation(async () => {
+    if (rejection !== undefined) {
+      throw rejection
+    }
+    return result
+  })
+  return chain
+}
+
+function createDb(input: {
+  storedRows?: unknown[][]
+  updateError?: Error
+  updatedRows?: unknown[]
+}) {
+  const storedRows = input.storedRows ?? [[{ objectKey: null }]]
+  const select = vi.fn()
+  for (const rows of storedRows) {
+    select.mockReturnValueOnce(selectChain(rows))
+  }
+  select.mockReturnValueOnce(selectChain([{
+    albumId: 'album-1',
+    source: 'dashboard-upload',
+  }]))
+
+  const insertValues = vi.fn().mockResolvedValue(undefined)
+  const insert = vi.fn(() => ({ values: insertValues }))
+  const returning = input.updateError === undefined
+    ? vi.fn().mockResolvedValue(input.updatedRows ?? [{ id: 'image-1' }])
+    : vi.fn().mockRejectedValue(input.updateError)
+  const updateChain = {
+    set: vi.fn(),
+    where: vi.fn(),
+    returning,
+  }
+  updateChain.set.mockReturnValue(updateChain)
+  updateChain.where.mockReturnValue(updateChain)
+  const update = vi.fn(() => updateChain)
+
+  return { select, insert, update, insertValues }
+}
+
+const bindings = {
+  db: {} as D1Database,
+  r2: {} as R2Bucket,
+}
+
+describe('persistMissingThumbnail', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mocks.buildThumbnailR2ObjectKey.mockReturnValue('thumbnails/2026/07/16/thumb.webp')
+    mocks.putImageObject.mockResolvedValue(undefined)
+    mocks.cleanupUncommittedUpload.mockResolvedValue(undefined)
+    mocks.releaseStorageReservation.mockResolvedValue(undefined)
+  })
+
+  it('reserves, writes, and atomically attaches a thumbnail', async () => {
+    const db = createDb({})
+    mocks.getDb.mockReturnValue(db)
+    const { persistMissingThumbnail } = await import('./thumbnailMaintenance')
+
+    const result = await persistMissingThumbnail({
+      ...bindings,
+      objectKey: 'image-1',
+      bytes: new Uint8Array([1, 2, 3]).buffer,
+      width: 48,
+      height: 32,
+    })
+
+    expect(db.insertValues).toHaveBeenCalledWith(expect.objectContaining({
+      objectKey: 'thumbnails/2026/07/16/thumb.webp',
+      bytesReserved: 3,
+    }))
+    expect(mocks.putImageObject).toHaveBeenCalledWith(bindings.r2, expect.objectContaining({
+      key: 'thumbnails/2026/07/16/thumb.webp',
+      mime: 'image/webp',
+    }))
+    expect(result).toMatchObject({ alreadyPresent: false, thumbnail: { width: 48, height: 32 } })
+    expect(mocks.cleanupUncommittedUpload).not.toHaveBeenCalled()
+  })
+
+  it('cleans the reserved object when the R2 write fails', async () => {
+    const db = createDb({})
+    mocks.getDb.mockReturnValue(db)
+    mocks.putImageObject.mockRejectedValueOnce(new Error('R2 unavailable'))
+    const { persistMissingThumbnail } = await import('./thumbnailMaintenance')
+
+    await expect(persistMissingThumbnail({
+      ...bindings,
+      objectKey: 'image-1',
+      bytes: new Uint8Array([1]).buffer,
+      width: 1,
+      height: 1,
+    })).rejects.toThrow('R2 unavailable')
+
+    expect(mocks.cleanupUncommittedUpload).toHaveBeenCalledOnce()
+  })
+
+  it('retains the object and reservation when D1 commit state is unknown', async () => {
+    const db = createDb({
+      storedRows: [
+        [{ objectKey: null }],
+        [],
+      ],
+      updateError: new Error('D1 response lost'),
+    })
+    // The state check after the failed UPDATE must itself be unavailable.
+    db.select.mockReset()
+    db.select
+      .mockReturnValueOnce(selectChain([{ objectKey: null }]))
+      .mockReturnValueOnce(selectChain([{ albumId: 'album-1', source: 'dashboard-upload' }]))
+      .mockReturnValueOnce(selectChain([], new Error('D1 unavailable')))
+    mocks.getDb.mockReturnValue(db)
+    const { persistMissingThumbnail } = await import('./thumbnailMaintenance')
+
+    await expect(persistMissingThumbnail({
+      ...bindings,
+      objectKey: 'image-1',
+      bytes: new Uint8Array([1]).buffer,
+      width: 1,
+      height: 1,
+    })).rejects.toThrow('D1 response lost')
+
+    expect(mocks.cleanupUncommittedUpload).not.toHaveBeenCalled()
+    expect(mocks.releaseStorageReservation).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/storage/thumbnailMaintenance.ts
+++ b/src/lib/storage/thumbnailMaintenance.ts
@@ -1,0 +1,122 @@
+import type { ThumbnailImageAsset } from '@/lib/storage/types'
+import { getDb } from '@/lib/db/client'
+import { storageReservationsTable } from '@/lib/db/schema'
+import { buildThumbnailR2ObjectKey, putImageObject } from '@/lib/storage/r2Repo'
+import {
+  attachThumbnailIfMissing,
+  getStoredThumbnail,
+  getThumbnailImageContext,
+} from '@/lib/storage/thumbnailMaintenanceRepo'
+import {
+  cleanupUncommittedUpload,
+  releaseStorageReservation,
+} from '@/lib/storage/uploadReconciliation'
+
+/**
+ * Persists one browser-generated WebP thumbnail with quota reservation and
+ * failure-safe R2 cleanup.
+ */
+export async function persistMissingThumbnail(input: {
+  db: D1Database
+  r2: R2Bucket
+  objectKey: string
+  bytes: ArrayBuffer
+  width: number
+  height: number
+}): Promise<{ thumbnail: ThumbnailImageAsset, alreadyPresent: boolean }> {
+  const current = await getStoredThumbnail(input.db, input.objectKey)
+  if (current === undefined) {
+    throw new Error('Image not found')
+  }
+  if (current !== null) {
+    return { thumbnail: current, alreadyPresent: true }
+  }
+
+  const image = await getThumbnailImageContext(input.db, input.objectKey)
+  if (image === undefined) {
+    throw new Error('Image not found')
+  }
+
+  const thumbnail: ThumbnailImageAsset = {
+    objectKey: buildThumbnailR2ObjectKey(),
+    sizeBytes: input.bytes.byteLength,
+    mime: 'image/webp',
+    width: input.width,
+    height: input.height,
+  }
+  const uploadedAt = new Date().toISOString()
+
+  await getDb().insert(storageReservationsTable).values({
+    objectKey: thumbnail.objectKey,
+    bytesReserved: thumbnail.sizeBytes,
+    assetKeysJson: JSON.stringify([thumbnail.objectKey]),
+    createdAt: Date.now(),
+  })
+
+  try {
+    await putImageObject(input.r2, {
+      key: thumbnail.objectKey,
+      bytes: input.bytes,
+      mime: thumbnail.mime,
+      albumId: image.albumId,
+      source: image.source,
+      uploadedAt,
+    })
+  }
+  catch (error) {
+    await cleanupUncommittedUpload(
+      input.r2,
+      thumbnail.objectKey,
+      [thumbnail.objectKey],
+      error,
+    )
+    throw error
+  }
+
+  try {
+    if (await attachThumbnailIfMissing(input.db, { objectKey: input.objectKey, thumbnail })) {
+      return { thumbnail, alreadyPresent: false }
+    }
+
+    const stored = await getStoredThumbnail(input.db, input.objectKey)
+    await cleanupUncommittedUpload(
+      input.r2,
+      thumbnail.objectKey,
+      [thumbnail.objectKey],
+      new Error('Thumbnail was attached by another request'),
+    )
+    if (stored === undefined) {
+      throw new Error('Image not found')
+    }
+    if (stored === null) {
+      throw new Error('Thumbnail metadata was not saved')
+    }
+    return { thumbnail: stored, alreadyPresent: true }
+  }
+  catch (error) {
+    let stored: ThumbnailImageAsset | null | undefined
+    try {
+      stored = await getStoredThumbnail(input.db, input.objectKey)
+    }
+    catch (stateError) {
+      // A lost D1 response cannot prove that the UPDATE rolled back. Retain
+      // both the object and its reservation for bounded reconciliation.
+      console.error('[persistMissingThumbnail] Failed to determine metadata state:', stateError)
+      throw error
+    }
+    if (stored?.objectKey !== thumbnail.objectKey) {
+      await cleanupUncommittedUpload(
+        input.r2,
+        thumbnail.objectKey,
+        [thumbnail.objectKey],
+        error,
+      )
+      throw error
+    }
+
+    await releaseStorageReservation(thumbnail.objectKey).catch((releaseError) => {
+      console.error('[persistMissingThumbnail] Failed to release consumed reservation:', releaseError)
+    })
+    return { thumbnail, alreadyPresent: false }
+  }
+}

--- a/src/lib/storage/thumbnailMaintenanceRepo.ts
+++ b/src/lib/storage/thumbnailMaintenanceRepo.ts
@@ -1,0 +1,148 @@
+import type { ImageSource, ThumbnailImageAsset } from '@/lib/storage/types'
+import { and, asc, count, eq, gt, isNull } from 'drizzle-orm'
+import { getDb } from '@/lib/db/client'
+import { imagesTable } from '@/lib/db/schema'
+
+const DEFAULT_PAGE_SIZE = 8
+const MAX_PAGE_SIZE = 20
+
+export interface MissingThumbnailCandidate {
+  objectKey: string
+  albumId: string
+  storedName: string
+  mime: string
+  source: ImageSource
+}
+
+export interface MissingThumbnailPage {
+  items: MissingThumbnailCandidate[]
+  missingCount: number
+  nextCursor: string | null
+}
+
+function normalizePageSize(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return DEFAULT_PAGE_SIZE
+  }
+  return Math.max(1, Math.min(MAX_PAGE_SIZE, Math.trunc(value)))
+}
+
+/** Lists active images whose dedicated album thumbnail has not been generated. */
+export async function listMissingThumbnailCandidates(
+  _db: D1Database,
+  input: { cursor?: string | null, pageSize?: number },
+): Promise<MissingThumbnailPage> {
+  const db = getDb()
+  const pageSize = normalizePageSize(input.pageSize)
+  const conditions = [
+    isNull(imagesTable.deletedAt),
+    isNull(imagesTable.thumbnailObjectKey),
+  ]
+  if (input.cursor !== null && input.cursor !== undefined && input.cursor.length > 0) {
+    conditions.push(gt(imagesTable.id, input.cursor))
+  }
+
+  const [[summary], rows] = await Promise.all([
+    db
+      .select({ value: count() })
+      .from(imagesTable)
+      .where(and(isNull(imagesTable.deletedAt), isNull(imagesTable.thumbnailObjectKey))),
+    db
+      .select({
+        objectKey: imagesTable.id,
+        albumId: imagesTable.albumId,
+        storedName: imagesTable.storedName,
+        mime: imagesTable.mime,
+        source: imagesTable.source,
+      })
+      .from(imagesTable)
+      .where(and(...conditions))
+      .orderBy(asc(imagesTable.id))
+      .limit(pageSize + 1),
+  ])
+
+  const hasNextPage = rows.length > pageSize
+  const items = hasNextPage ? rows.slice(0, pageSize) : rows
+  return {
+    items,
+    missingCount: summary?.value ?? 0,
+    nextCursor: hasNextPage ? (items.at(-1)?.objectKey ?? null) : null,
+  }
+}
+
+/** Returns the current thumbnail metadata for an active image. */
+export async function getStoredThumbnail(
+  _db: D1Database,
+  objectKey: string,
+): Promise<ThumbnailImageAsset | null | undefined> {
+  const [row] = await getDb()
+    .select({
+      objectKey: imagesTable.thumbnailObjectKey,
+      sizeBytes: imagesTable.thumbnailBytes,
+      mime: imagesTable.thumbnailMime,
+      width: imagesTable.thumbnailWidth,
+      height: imagesTable.thumbnailHeight,
+    })
+    .from(imagesTable)
+    .where(and(eq(imagesTable.id, objectKey), isNull(imagesTable.deletedAt)))
+    .limit(1)
+
+  if (row === undefined) {
+    return undefined
+  }
+  if (row.objectKey === null) {
+    return null
+  }
+  if (
+    row.sizeBytes === null
+    || row.mime !== 'image/webp'
+    || row.width === null
+    || row.height === null
+  ) {
+    throw new Error('Stored thumbnail metadata is incomplete')
+  }
+  return {
+    objectKey: row.objectKey,
+    sizeBytes: row.sizeBytes,
+    mime: 'image/webp',
+    width: row.width,
+    height: row.height,
+  }
+}
+
+/** Loads the R2 tracing metadata needed for a thumbnail write. */
+export async function getThumbnailImageContext(
+  _db: D1Database,
+  objectKey: string,
+): Promise<{ albumId: string, source: ImageSource } | undefined> {
+  const [image] = await getDb()
+    .select({ albumId: imagesTable.albumId, source: imagesTable.source })
+    .from(imagesTable)
+    .where(and(eq(imagesTable.id, objectKey), isNull(imagesTable.deletedAt)))
+    .limit(1)
+  return image
+}
+
+/** Atomically attaches a thumbnail only while the image remains unprocessed. */
+export async function attachThumbnailIfMissing(
+  _db: D1Database,
+  input: { objectKey: string, thumbnail: ThumbnailImageAsset },
+): Promise<boolean> {
+  const rows = await getDb()
+    .update(imagesTable)
+    .set({
+      thumbnailObjectKey: input.thumbnail.objectKey,
+      thumbnailBytes: input.thumbnail.sizeBytes,
+      thumbnailMime: input.thumbnail.mime,
+      thumbnailWidth: input.thumbnail.width,
+      thumbnailHeight: input.thumbnail.height,
+      updatedAt: Date.now(),
+    })
+    .where(and(
+      eq(imagesTable.id, input.objectKey),
+      isNull(imagesTable.deletedAt),
+      isNull(imagesTable.thumbnailObjectKey),
+    ))
+    .returning({ id: imagesTable.id })
+  return rows.length === 1
+}


### PR DESCRIPTION
### 📌 Description

Fix the large-album memory regression by making dedicated WebP thumbnails the album preview source, backfilling legacy objects safely, and bounding browser-side image/ZIP memory. Also patch the reported production and development dependency advisories.

### 🔍 Key changes

- Add authenticated, resumable browser-side thumbnail maintenance for legacy images.
- Reserve thumbnail quota before R2 writes and consume the reservation atomically in the D1 image update trigger.
- Generate native JPEG/PNG/WebP/AVIF thumbnails with decode-time resize instead of a full-size canvas.
- Unmount offscreen album/home `<img>` elements while keeping stable row/selection state.
- Cap the home queue at 200 images / 256 MiB of source data and reject ZIP batches above 128 MiB.
- Pin patched transitive versions in `pnpm-workspace.yaml`; both production and full audits now report no known vulnerabilities.

### ✅ Testing

- `pnpm lint` (passes with one pre-existing `DeleteAlbumDialog.tsx` warning)
- `pnpm test` — 13 files, 47 tests
- `pnpm build`
- `pnpm audit --prod`
- `pnpm audit`
- `pnpm exec drizzle-kit generate --config=/tmp/momopix-drizzle-smoke.config.ts`
- Local migration/trigger verification from a legacy schema

### 🖥 UI and memory verification

- Real 48-image / 89 MiB album, repeated scroll sweeps: renderer peak reduced from about 2.1 GiB to 243 MiB after the thumbnail backfill.
- Album mounted at most 15 image elements; selection preserved existing visible image DOM nodes.
- Home page with 200 images / 85 MiB mounted at most 11 image elements; renderer peak was 426 MiB.
- Checked the dashboard at 390 px width: no horizontal overflow; loading/maintenance progress and pause/resume states exercised.
- Added generation isolation plus a visible `Pausing…` gate, so Resume waits for any in-flight write to settle.

### 🗄 Production data verification

- Applied migrations `0005` and `0006` to production D1 before application deployment.
- Backfilled 183 / 183 active images with WebP thumbnails (4,716,650 bytes, max edge 512 px).
- Verified `storage_quota.bytes_used` exactly matches hosted + original + thumbnail bytes (232,123,602 bytes).
- Verified zero remaining storage reservations and zero missing thumbnails.
- Verified the production R2 bucket allows browser GET/HEAD CORS for the maintenance flow.

### Risks / follow-ups

- The legacy maintenance card disappears once all images have thumbnails; new uploads already create thumbnails in the normal upload flow.
- RAW worker cross-origin isolation, trusted original-dimension extraction, and a Worker-global single-consumer queue remain separate backlog items and are not regressions introduced here.

### AGENTS.md Update

- Updated: thumbnail backfill reservation/trigger invariant
- Breaking: No
- Migration: apply `0006_thumbnail_backfill_reservations.sql` after `0005`
- New env var/binding: N/A
- Deprecated pattern: full hosted image as album preview -> dedicated WebP thumbnail
