### PR TITLE
feat(dashboard): restore compression and improve image discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,7 @@ Pagination invariants:
 
 - Use stable, deterministic ordering for listings (keyset pagination preferred).
 - Keep cursor semantics consistent across endpoints (document the ordering key and tie-break).
+- Image listing cursors encode the active sort plus its primary value and image id; changing sort or filters must reset cursor state.
 
 Image URL invariants:
 

--- a/migrations/0007_image_browse_indexes.sql
+++ b/migrations/0007_image_browse_indexes.sql
@@ -1,0 +1,17 @@
+CREATE INDEX IF NOT EXISTS idx_images_album_name_sort
+  ON images(album_id, name_lower, id);
+
+CREATE INDEX IF NOT EXISTS idx_images_album_bytes_sort
+  ON images(album_id, bytes, id);
+
+CREATE INDEX IF NOT EXISTS idx_images_album_ext_sort
+  ON images(album_id, ext, id);
+
+CREATE INDEX IF NOT EXISTS idx_images_name_sort
+  ON images(name_lower, id);
+
+CREATE INDEX IF NOT EXISTS idx_images_bytes_sort
+  ON images(bytes, id);
+
+CREATE INDEX IF NOT EXISTS idx_images_ext_sort
+  ON images(ext, id);

--- a/src/components/devtools/DevelopmentDevtools.tsx
+++ b/src/components/devtools/DevelopmentDevtools.tsx
@@ -1,0 +1,15 @@
+import { TanStackDevtools } from '@tanstack/react-devtools'
+import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
+
+/** Development-only router/query inspection controls. */
+export function DevelopmentDevtools() {
+  return (
+    <TanStackDevtools
+      config={{ position: 'bottom-right' }}
+      plugins={[{
+        name: 'Tanstack Router',
+        render: <TanStackRouterDevtoolsPanel />,
+      }]}
+    />
+  )
+}

--- a/src/features/dashboard/components/DashboardFeature.tsx
+++ b/src/features/dashboard/components/DashboardFeature.tsx
@@ -35,6 +35,12 @@ export function DashboardFeature() {
     ...search,
     page: search.page ?? 1,
     pageSize: typeof search.pageSize === 'number' ? search.pageSize : 50,
+    sort: search.sort ?? 'createdAt-desc',
+    format: search.format ?? 'all',
+    orientation: search.orientation ?? 'all',
+    date: search.date ?? 'all',
+    resolution: search.resolution ?? 'all',
+    scope: search.scope ?? 'album',
   }), [search])
   const onUrlStateChange = useCallback((next: Partial<DashboardUrlState>, replace = false) => {
     void navigate({
@@ -84,6 +90,18 @@ export function DashboardFeature() {
     isSearchMode,
     searchQuery,
     onSearchQueryChange,
+    sort,
+    format,
+    orientation,
+    date,
+    resolution,
+    scope,
+    onSortChange,
+    onFormatChange,
+    onOrientationChange,
+    onDateChange,
+    onResolutionChange,
+    onScopeChange,
     setDefaultAlbum,
     setMobileSidebarOpen,
     setRenameImageObjectKey,
@@ -120,6 +138,8 @@ export function DashboardFeature() {
     images,
     pageIndex: pageIndexZeroBased,
     pageSize,
+    albums,
+    showAlbumColumn: scope === 'all',
     onRenameImage: handleRenameImageRequest,
     onMoveImage: handleMoveImageRequest,
     onDeleteImage: handleDeleteImageRequest,
@@ -189,7 +209,7 @@ export function DashboardFeature() {
             <div>
               <CardTitle className="flex items-center gap-2">
                 <ImageIcon className="h-4 w-4" />
-                {selectedAlbum?.name ?? 'Images'}
+                {scope === 'all' ? 'All images' : (selectedAlbum?.name ?? 'Images')}
                 {imagesStatus.isFetching && !imagesStatus.isInitialLoading && (
                   <Spinner className="h-4 w-4 text-muted-foreground" />
                 )}
@@ -222,7 +242,9 @@ export function DashboardFeature() {
                     )}
               </CardDescription>
             </div>
-            <Badge variant="secondary">{formatBytes(selectedAlbum?.bytesUsed ?? 0)}</Badge>
+            <Badge variant="secondary">
+              {formatBytes(scope === 'all' ? (meta?.totalBytesUsed ?? 0) : (selectedAlbum?.bytesUsed ?? 0))}
+            </Badge>
           </div>
 
           <DashboardTopbar
@@ -252,6 +274,18 @@ export function DashboardFeature() {
                 setSelectionToObjectKeys={setSelectionToObjectKeys}
               />
             )}
+            sort={sort}
+            format={format}
+            orientation={orientation}
+            date={date}
+            resolution={resolution}
+            scope={scope}
+            onSortChange={onSortChange}
+            onFormatChange={onFormatChange}
+            onOrientationChange={onOrientationChange}
+            onDateChange={onDateChange}
+            onResolutionChange={onResolutionChange}
+            onScopeChange={onScopeChange}
           />
         </CardHeader>
         <CardContent>

--- a/src/features/dashboard/components/DashboardTopbar.tsx
+++ b/src/features/dashboard/components/DashboardTopbar.tsx
@@ -1,10 +1,13 @@
 import type { ReactNode } from 'react'
 import type { UploadProgress } from '@/features/dashboard/hooks/useUpload'
+import type { DashboardImageScope } from '@/features/dashboard/lib/urlState'
+import type { ImageDateFilter, ImageFormatFilter, ImageListSort, ImageOrientationFilter, ImageResolutionFilter } from '@/lib/storage/types'
 import { Search, Upload } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { LoadingButton } from '@/components/ui/loading-button'
 import { Progress } from '@/components/ui/progress'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 
 interface DashboardTopbarProps {
   search: string
@@ -18,6 +21,18 @@ interface DashboardTopbarProps {
   onRetryFailedUploads: () => void
   fileInputRef: React.RefObject<HTMLInputElement | null>
   bulkOptions: ReactNode
+  sort: ImageListSort
+  format: ImageFormatFilter
+  orientation: ImageOrientationFilter
+  date: ImageDateFilter
+  resolution: ImageResolutionFilter
+  scope: DashboardImageScope
+  onSortChange: (value: ImageListSort) => void
+  onFormatChange: (value: ImageFormatFilter) => void
+  onOrientationChange: (value: ImageOrientationFilter) => void
+  onDateChange: (value: ImageDateFilter) => void
+  onResolutionChange: (value: ImageResolutionFilter) => void
+  onScopeChange: (value: DashboardImageScope) => void
 }
 
 export function DashboardTopbar({
@@ -32,6 +47,18 @@ export function DashboardTopbar({
   onRetryFailedUploads,
   fileInputRef,
   bulkOptions,
+  sort,
+  format,
+  orientation,
+  date,
+  resolution,
+  scope,
+  onSortChange,
+  onFormatChange,
+  onOrientationChange,
+  onDateChange,
+  onResolutionChange,
+  onScopeChange,
 }: DashboardTopbarProps) {
   return (
     <div className="space-y-2">
@@ -65,6 +92,81 @@ export function DashboardTopbar({
           onChange={event_ => onUploadChange(event_.target.files)}
         />
         {bulkOptions}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Select value={scope} onValueChange={value => onScopeChange(value as DashboardImageScope)}>
+          <SelectTrigger size="sm" className="min-w-36" aria-label="Choose image scope">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="album">Current album</SelectItem>
+            <SelectItem value="all">All albums</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={sort} onValueChange={value => onSortChange(value as ImageListSort)}>
+          <SelectTrigger size="sm" className="min-w-42" aria-label="Sort images">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="createdAt-desc">Newest first</SelectItem>
+            <SelectItem value="createdAt-asc">Oldest first</SelectItem>
+            <SelectItem value="name-asc">Name A–Z</SelectItem>
+            <SelectItem value="name-desc">Name Z–A</SelectItem>
+            <SelectItem value="sizeBytes-desc">Largest first</SelectItem>
+            <SelectItem value="sizeBytes-asc">Smallest first</SelectItem>
+            <SelectItem value="type-asc">Type A–Z</SelectItem>
+            <SelectItem value="type-desc">Type Z–A</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={format} onValueChange={value => onFormatChange(value as ImageFormatFilter)}>
+          <SelectTrigger size="sm" className="min-w-30" aria-label="Filter by format">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All formats</SelectItem>
+            <SelectItem value="avif">AVIF</SelectItem>
+            <SelectItem value="bmp">BMP</SelectItem>
+            <SelectItem value="gif">GIF</SelectItem>
+            <SelectItem value="jpeg">JPEG</SelectItem>
+            <SelectItem value="png">PNG</SelectItem>
+            <SelectItem value="webp">WebP</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={orientation} onValueChange={value => onOrientationChange(value as ImageOrientationFilter)}>
+          <SelectTrigger size="sm" className="min-w-32" aria-label="Filter by orientation">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All shapes</SelectItem>
+            <SelectItem value="landscape">Landscape</SelectItem>
+            <SelectItem value="portrait">Portrait</SelectItem>
+            <SelectItem value="square">Square</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={date} onValueChange={value => onDateChange(value as ImageDateFilter)}>
+          <SelectTrigger size="sm" className="min-w-32" aria-label="Filter by upload date">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Any date</SelectItem>
+            <SelectItem value="today">Past day</SelectItem>
+            <SelectItem value="7d">Past 7 days</SelectItem>
+            <SelectItem value="30d">Past 30 days</SelectItem>
+            <SelectItem value="1y">Past year</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={resolution} onValueChange={value => onResolutionChange(value as ImageResolutionFilter)}>
+          <SelectTrigger size="sm" className="min-w-36" aria-label="Filter by resolution">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All resolutions</SelectItem>
+            <SelectItem value="under-2mp">Under 2 MP</SelectItem>
+            <SelectItem value="2-12mp">2–12 MP</SelectItem>
+            <SelectItem value="12-24mp">12–24 MP</SelectItem>
+            <SelectItem value="over-24mp">Over 24 MP</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
       {uploadProgress !== null && (
         <div className="rounded-md border bg-muted/40 px-3 py-2" role="status" aria-live="polite">

--- a/src/features/dashboard/components/ImageActionsMenu.tsx
+++ b/src/features/dashboard/components/ImageActionsMenu.tsx
@@ -1,6 +1,6 @@
 import type { ComponentType, ReactNode } from 'react'
 import type { AlbumImageListItem } from '@/lib/storage/types'
-import { Code2, Link2, MoreHorizontal, MoveRight, Pencil, Trash2, UserRoundSearch } from 'lucide-react'
+import { Code2, Download, Link2, MoreHorizontal, MoveRight, Pencil, Trash2, UserRoundSearch } from 'lucide-react'
 import { useTransition } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -89,6 +89,17 @@ function ImageActionsContent({
       >
         <UserRoundSearch className="mr-2 h-4 w-4" />
         {hasPublicUrl ? 'View' : 'View (Unavailable)'}
+      </Item>
+      <Item
+        disabled={image.originalDownloadUrl === null}
+        onSelect={() => {
+          if (image.originalDownloadUrl !== null) {
+            window.location.assign(image.originalDownloadUrl)
+          }
+        }}
+      >
+        <Download className="mr-2 h-4 w-4" />
+        {image.originalDownloadUrl === null ? 'Download original (Unavailable)' : 'Download original'}
       </Item>
       <Item onSelect={() => onRenameImage(image.objectKey)}>
         <Pencil className="mr-2 h-4 w-4" />

--- a/src/features/dashboard/dialogs/AlbumDialogs.tsx
+++ b/src/features/dashboard/dialogs/AlbumDialogs.tsx
@@ -8,16 +8,9 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { LoadingButton } from '@/components/ui/loading-button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { ROOT_ALBUM_ID } from '@/lib/storage/types'
+import { formatAlbumPath } from '@/lib/storage/albumLabel'
 
 const NO_PARENT_VALUE = '__none__'
-
-function displayAlbumName(album: AlbumRecord): string {
-  if (album.id === ROOT_ALBUM_ID) {
-    return 'Default'
-  }
-  return album.name
-}
 
 interface AlbumDialogsProps {
   albums: AlbumRecord[]
@@ -214,7 +207,7 @@ export function AlbumDialogs({
                     <SelectContent>
                       <SelectItem value={NO_PARENT_VALUE}>No parent (top-level)</SelectItem>
                       {albums.map(album => (
-                        <SelectItem key={album.id} value={album.id}>{displayAlbumName(album)}</SelectItem>
+                        <SelectItem key={album.id} value={album.id}>{formatAlbumPath(album, albums)}</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
@@ -341,7 +334,7 @@ export function AlbumDialogs({
                     <SelectContent>
                       <SelectItem value={NO_PARENT_VALUE}>No parent (top-level)</SelectItem>
                       {albums.filter(album => album.id !== moveAlbumId).map(album => (
-                        <SelectItem key={album.id} value={album.id}>{displayAlbumName(album)}</SelectItem>
+                        <SelectItem key={album.id} value={album.id}>{formatAlbumPath(album, albums)}</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>

--- a/src/features/dashboard/dialogs/BulkMoveImagesDialog.tsx
+++ b/src/features/dashboard/dialogs/BulkMoveImagesDialog.tsx
@@ -7,6 +7,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Label } from '@/components/ui/label'
 import { LoadingButton } from '@/components/ui/loading-button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { formatAlbumPath } from '@/lib/storage/albumLabel'
 
 interface BulkMoveImagesDialogProps {
   open: boolean
@@ -109,7 +110,7 @@ export function BulkMoveImagesDialog({
                     </SelectTrigger>
                     <SelectContent>
                       {albums.map(album => (
-                        <SelectItem key={album.id} value={album.id}>{album.name}</SelectItem>
+                        <SelectItem key={album.id} value={album.id}>{formatAlbumPath(album, albums)}</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>

--- a/src/features/dashboard/dialogs/DeleteAlbumDialog.tsx
+++ b/src/features/dashboard/dialogs/DeleteAlbumDialog.tsx
@@ -1,12 +1,13 @@
 import type { AlbumRecord } from '@/lib/storage/types'
 import { AlertTriangle } from 'lucide-react'
-import { useEffect, useState, useTransition } from 'react'
+import { useState, useTransition } from 'react'
 import { toast } from 'sonner'
 import { AlertDialog, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogMedia, AlertDialogTitle } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { LoadingButton } from '@/components/ui/loading-button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { formatAlbumPath } from '@/lib/storage/albumLabel'
 import { ROOT_ALBUM_ID } from '@/lib/storage/types'
 
 interface DeleteAlbumDialogProps {
@@ -16,22 +17,18 @@ interface DeleteAlbumDialogProps {
   onCancel: () => void
 }
 
-function displayAlbumName(album: AlbumRecord): string {
-  return album.id === ROOT_ALBUM_ID ? 'Default' : album.name
-}
-
 /** Confirms album deletion after selecting where its contents will be migrated. */
 export function DeleteAlbumDialog({ album, albums, onDelete, onCancel }: DeleteAlbumDialogProps) {
   const [isTransitionPending, startTransition] = useTransition()
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [targetAlbumId, setTargetAlbumId] = useState<string>(ROOT_ALBUM_ID)
+  const [selection, setSelection] = useState({
+    albumId: album?.id ?? null,
+    targetAlbumId: album?.parentId ?? ROOT_ALBUM_ID,
+  })
+  const targetAlbumId = selection.albumId === album?.id
+    ? selection.targetAlbumId
+    : (album?.parentId ?? ROOT_ALBUM_ID)
   const isPending = isTransitionPending || isSubmitting
-
-  useEffect(() => {
-    if (album !== null) {
-      setTargetAlbumId(album.parentId ?? ROOT_ALBUM_ID)
-    }
-  }, [album])
 
   const handleConfirm = () => {
     if (album === null || isSubmitting) {
@@ -57,11 +54,15 @@ export function DeleteAlbumDialog({ album, albums, onDelete, onCancel }: DeleteA
         </AlertDialogHeader>
         <div className="space-y-2">
           <Label htmlFor="delete-album-target">Move contents to</Label>
-          <Select value={targetAlbumId} onValueChange={setTargetAlbumId} disabled={isPending}>
+          <Select
+            value={targetAlbumId}
+            onValueChange={value => setSelection({ albumId: album?.id ?? null, targetAlbumId: value })}
+            disabled={isPending}
+          >
             <SelectTrigger id="delete-album-target"><SelectValue /></SelectTrigger>
             <SelectContent>
               {albums.filter(item => item.id !== album?.id && !item.path.includes(album?.id ?? '')).map(item => (
-                <SelectItem key={item.id} value={item.id}>{displayAlbumName(item)}</SelectItem>
+                <SelectItem key={item.id} value={item.id}>{formatAlbumPath(item, albums)}</SelectItem>
               ))}
             </SelectContent>
           </Select>

--- a/src/features/dashboard/hooks/useDashboardData.ts
+++ b/src/features/dashboard/hooks/useDashboardData.ts
@@ -1,4 +1,4 @@
-import type { DashboardUrlState } from '@/features/dashboard/lib/urlState'
+import type { DashboardImageScope, DashboardUrlState } from '@/features/dashboard/lib/urlState'
 import type {
   BulkMoveImagesInput,
   BulkOperationResult,
@@ -8,7 +8,7 @@ import type {
   RenameAlbumInput,
   RenameImageInput,
 } from '@/features/dashboard/types'
-import type { AlbumImageListItem, AlbumRecord, StorageMeta } from '@/lib/storage/types'
+import type { AlbumImageListItem, AlbumRecord, ImageDateFilter, ImageFormatFilter, ImageListSort, ImageOrientationFilter, ImageResolutionFilter, StorageMeta } from '@/lib/storage/types'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useTransition } from 'react'
 import { toast } from 'sonner'
 import { useUpload } from '@/features/dashboard/hooks/useUpload'
@@ -26,11 +26,8 @@ const DEFAULT_IMAGE_PAGE_SIZE = 50
  * Delay used before applying search queries to server fetches.
  */
 const SEARCH_DEBOUNCE_MS = 250
-/**
- * Largest page number accepted from a search deep link before requiring normal Next navigation.
- */
-const MAX_SEARCH_DEEP_LINK_PAGE_INDEX = 20
-
+/** Prevent a forged/deep URL from replaying an unbounded cursor chain. */
+const MAX_CURSOR_WARMUP_PAGES = 20
 type LoadState = 'idle' | 'loading' | 'success' | 'error'
 
 interface UseDashboardDataOptions {
@@ -49,6 +46,12 @@ export function useDashboardData(options: UseDashboardDataOptions) {
   const urlQuery = normalizeDashboardQuery(urlState.q ?? '') ?? ''
   const urlPageIndex = urlState.page - 1
   const urlPageSize = urlState.pageSize
+  const urlSort = urlState.sort
+  const urlFormat = urlState.format
+  const urlOrientation = urlState.orientation
+  const urlDate = urlState.date
+  const urlResolution = urlState.resolution
+  const urlScope = urlState.scope
   const [albums, setAlbums] = useState<AlbumRecord[]>([])
   const [meta, setMeta] = useState<StorageMeta | null>(null)
   const [selectedAlbumId, setSelectedAlbumId] = useState<string>(urlAlbumId)
@@ -62,6 +65,12 @@ export function useDashboardData(options: UseDashboardDataOptions) {
   const pageIndexRef = useRef(pageIndex)
   const [imagesRevision, setImagesRevision] = useState(0)
   const [pageSize, setPageSize] = useState(urlPageSize ?? DEFAULT_IMAGE_PAGE_SIZE)
+  const [sort, setSort] = useState<ImageListSort>(urlSort)
+  const [format, setFormat] = useState<ImageFormatFilter>(urlFormat)
+  const [orientation, setOrientation] = useState<ImageOrientationFilter>(urlOrientation)
+  const [date, setDate] = useState<ImageDateFilter>(urlDate)
+  const [resolution, setResolution] = useState<ImageResolutionFilter>(urlResolution)
+  const [scope, setScope] = useState<DashboardImageScope>(urlScope)
   const [searchQuery, setSearchQuery] = useState(urlQuery)
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(urlQuery)
   const [isAlbumsLoaded, setIsAlbumsLoaded] = useState(false)
@@ -78,12 +87,18 @@ export function useDashboardData(options: UseDashboardDataOptions) {
 
   const albumById = useMemo(() => new Map(albums.map(album => [album.id, album])), [albums])
   const selectedAlbum = albumById.get(selectedAlbumId) ?? null
-  const currentViewKey = `${selectedAlbumId}|${debouncedSearchQuery}|${pageSize}|${imagesRevision}`
+  const currentViewKey = `${scope}|${selectedAlbumId}|${debouncedSearchQuery}|${sort}|${format}|${orientation}|${resolution}|${date}|${pageSize}|${imagesRevision}`
   const currentPageKey = `${currentViewKey}|${pageIndex}`
   const hasLoadedCurrentPage = loadedPageKey === currentPageKey
   const hasLoadedAnyPage = loadedPageKey !== null
   const isSearchMode = debouncedSearchQuery.length > 0
-  const totalCount = isSearchMode ? null : (selectedAlbum?.imageCount ?? 0)
+    || format !== 'all'
+    || orientation !== 'all'
+    || resolution !== 'all'
+    || date !== 'all'
+  const totalCount = isSearchMode
+    ? null
+    : (scope === 'all' ? (meta?.totalImageCount ?? 0) : (selectedAlbum?.imageCount ?? 0))
   const totalPages = totalCount === null ? null : Math.max(1, Math.ceil(totalCount / pageSize))
   const hasPreviousPage = pageIndex > 0
   const isFetching = isImagesFetching || isViewTransitionPending
@@ -101,8 +116,14 @@ export function useDashboardData(options: UseDashboardDataOptions) {
     setPageIndex(current => current === urlPageIndex ? current : urlPageIndex)
     pageIndexRef.current = urlPageIndex
     setPageSize(current => current === urlPageSize ? current : urlPageSize)
+    setSort(current => current === urlSort ? current : urlSort)
+    setFormat(current => current === urlFormat ? current : urlFormat)
+    setOrientation(current => current === urlOrientation ? current : urlOrientation)
+    setDate(current => current === urlDate ? current : urlDate)
+    setResolution(current => current === urlResolution ? current : urlResolution)
+    setScope(current => current === urlScope ? current : urlScope)
     /* eslint-enable react/set-state-in-effect */
-  }, [urlAlbumId, urlPageIndex, urlPageSize, urlQuery])
+  }, [urlAlbumId, urlDate, urlFormat, urlOrientation, urlPageIndex, urlPageSize, urlQuery, urlResolution, urlScope, urlSort])
 
   useLayoutEffect(() => {
     selectedAlbumIdRef.current = selectedAlbumId
@@ -113,14 +134,25 @@ export function useDashboardData(options: UseDashboardDataOptions) {
     cursor: string | null
     query: string
     pageSize: number
+    sort: ImageListSort
+    format: ImageFormatFilter
+    orientation: ImageOrientationFilter
+    date: ImageDateFilter
+    resolution: ImageResolutionFilter
+    scope: DashboardImageScope
   }) => {
     return listImagesFn({
       data: {
         albumId: input.albumId,
         cursor: input.cursor,
         pageSize: input.pageSize,
-        sort: 'createdAt-desc',
+        sort: input.sort,
         query: input.query,
+        format: input.format,
+        orientation: input.orientation,
+        date: input.date,
+        resolution: input.resolution,
+        allAlbums: input.scope === 'all',
       },
     })
   }, [])
@@ -148,9 +180,7 @@ export function useDashboardData(options: UseDashboardDataOptions) {
     viewKey: string
     pageIndex: number
   }) => {
-    const maximumPageIndex = isSearchMode
-      ? MAX_SEARCH_DEEP_LINK_PAGE_INDEX
-      : (totalPages === null ? null : totalPages - 1)
+    const maximumPageIndex = totalPages === null ? null : totalPages - 1
     if (maximumPageIndex !== null && input.pageIndex > maximumPageIndex) {
       pageIndexRef.current = maximumPageIndex
       setPageIndex(maximumPageIndex)
@@ -169,6 +199,12 @@ export function useDashboardData(options: UseDashboardDataOptions) {
       const cursorByPage = cursorByViewRef.current.get(input.viewKey) ?? new Map([[0, null]])
       cursorByViewRef.current.set(input.viewKey, cursorByPage)
       const cursorStart = getCursorNavigationStart(cursorByPage, input.pageIndex)
+      if (input.pageIndex - cursorStart.pageIndex > MAX_CURSOR_WARMUP_PAGES) {
+        pageIndexRef.current = 0
+        setPageIndex(0)
+        onUrlStateChange({ page: 1 }, true)
+        return
+      }
       let resolvedPageIndex = cursorStart.pageIndex
       let cursor = cursorStart.cursor
 
@@ -179,6 +215,12 @@ export function useDashboardData(options: UseDashboardDataOptions) {
           cursor,
           query: input.query,
           pageSize,
+          sort,
+          format,
+          orientation,
+          date,
+          resolution,
+          scope,
         })
 
         if (requestId !== imageRequestIdRef.current) {
@@ -207,6 +249,12 @@ export function useDashboardData(options: UseDashboardDataOptions) {
         cursor: cursor ?? null,
         query: input.query,
         pageSize,
+        sort,
+        format,
+        orientation,
+        date,
+        resolution,
+        scope,
       })
 
       if (requestId !== imageRequestIdRef.current) {
@@ -241,7 +289,7 @@ export function useDashboardData(options: UseDashboardDataOptions) {
         setIsImagesFetching(false)
       }
     }
-  }, [fetchImagesPage, isSearchMode, onUrlStateChange, pageSize, totalPages])
+  }, [date, fetchImagesPage, format, onUrlStateChange, orientation, pageSize, resolution, scope, sort, totalPages])
 
   const refreshImages = useCallback(() => {
     imageRequestIdRef.current += 1
@@ -482,16 +530,27 @@ export function useDashboardData(options: UseDashboardDataOptions) {
     if (result.succeededObjectKeys.length > 0) {
       refreshImages()
     }
-    if (targetAlbumId !== selectedAlbumId && sourceImages.length > 0) {
-      const bytesUsed = sourceImages.reduce((total, image) => total + image.storageBytes, 0)
-      updateAlbumUsage(new Map([
-        [selectedAlbumId, { imageCount: -sourceImages.length, bytesUsed: -bytesUsed }],
-        [targetAlbumId, { imageCount: sourceImages.length, bytesUsed }],
-      ]))
+    if (sourceImages.length > 0) {
+      const changes = new Map<string, { imageCount: number, bytesUsed: number }>()
+      for (const image of sourceImages) {
+        if (image.albumId === targetAlbumId) {
+          continue
+        }
+        const sourceChange = changes.get(image.albumId) ?? { imageCount: 0, bytesUsed: 0 }
+        sourceChange.imageCount -= 1
+        sourceChange.bytesUsed -= image.storageBytes
+        changes.set(image.albumId, sourceChange)
+
+        const targetChange = changes.get(targetAlbumId) ?? { imageCount: 0, bytesUsed: 0 }
+        targetChange.imageCount += 1
+        targetChange.bytesUsed += image.storageBytes
+        changes.set(targetAlbumId, targetChange)
+      }
+      updateAlbumUsage(changes)
     }
 
     return result
-  }, [images, refreshImages, selectedAlbumId, updateAlbumUsage])
+  }, [images, refreshImages, updateAlbumUsage])
 
   const bulkDeleteImages = useCallback(async (objectKeys: string[]): Promise<BulkOperationResult> => {
     const result = await deleteImagesFn({
@@ -505,12 +564,15 @@ export function useDashboardData(options: UseDashboardDataOptions) {
     }
     const cleanedImages = deletedImages.filter(image => !result.cleanupPendingObjectKeys.includes(image.objectKey))
     if (deletedImages.length > 0) {
-      const albumBytesUsed = deletedImages.reduce((total, image) => total + image.storageBytes, 0)
       const releasedBytes = cleanedImages.reduce((total, image) => total + image.storageBytes, 0)
-      updateAlbumUsage(new Map([[
-        selectedAlbumId,
-        { imageCount: -deletedImages.length, bytesUsed: -albumBytesUsed },
-      ]]))
+      const changes = new Map<string, { imageCount: number, bytesUsed: number }>()
+      for (const image of deletedImages) {
+        const change = changes.get(image.albumId) ?? { imageCount: 0, bytesUsed: 0 }
+        change.imageCount -= 1
+        change.bytesUsed -= image.storageBytes
+        changes.set(image.albumId, change)
+      }
+      updateAlbumUsage(changes)
       setMeta(previous => previous === null
         ? previous
         : {
@@ -526,7 +588,7 @@ export function useDashboardData(options: UseDashboardDataOptions) {
     }
 
     return result
-  }, [images, refreshImages, selectedAlbumId, updateAlbumUsage])
+  }, [images, refreshImages, updateAlbumUsage])
 
   const goNextPage = useCallback(() => {
     const nextIndex = pageIndexRef.current + 1
@@ -574,13 +636,48 @@ export function useDashboardData(options: UseDashboardDataOptions) {
     onUrlStateChange({ page: 1, q: normalizeDashboardQuery(value) }, true)
   }, [onUrlStateChange, startViewTransition])
 
+  const updateImageView = useCallback((next: {
+    sort?: ImageListSort
+    format?: ImageFormatFilter
+    orientation?: ImageOrientationFilter
+    date?: ImageDateFilter
+    resolution?: ImageResolutionFilter
+    scope?: DashboardImageScope
+  }) => {
+    pageIndexRef.current = 0
+    cursorByViewRef.current.clear()
+    startViewTransition(() => {
+      if (next.sort !== undefined) {
+        setSort(next.sort)
+      }
+      if (next.format !== undefined) {
+        setFormat(next.format)
+      }
+      if (next.orientation !== undefined) {
+        setOrientation(next.orientation)
+      }
+      if (next.date !== undefined) {
+        setDate(next.date)
+      }
+      if (next.resolution !== undefined) {
+        setResolution(next.resolution)
+      }
+      if (next.scope !== undefined) {
+        setScope(next.scope)
+      }
+      setPageIndex(0)
+    })
+    onUrlStateChange({ page: 1, ...next })
+  }, [onUrlStateChange, startViewTransition])
+
   const selectAlbum = useCallback((albumId: string) => {
     pageIndexRef.current = 0
     startViewTransition(() => {
       setSelectedAlbumId(albumId)
+      setScope('album')
       setPageIndex(0)
     })
-    onUrlStateChange({ album: albumId, page: 1 })
+    onUrlStateChange({ album: albumId, page: 1, scope: 'album' })
   }, [onUrlStateChange, startViewTransition])
 
   return {
@@ -620,6 +717,18 @@ export function useDashboardData(options: UseDashboardDataOptions) {
     deleteAlbum,
     searchQuery,
     onSearchQueryChange,
+    sort,
+    format,
+    orientation,
+    date,
+    resolution,
+    scope,
+    onSortChange: (value: ImageListSort) => updateImageView({ sort: value }),
+    onFormatChange: (value: ImageFormatFilter) => updateImageView({ format: value }),
+    onOrientationChange: (value: ImageOrientationFilter) => updateImageView({ orientation: value }),
+    onDateChange: (value: ImageDateFilter) => updateImageView({ date: value }),
+    onResolutionChange: (value: ImageResolutionFilter) => updateImageView({ resolution: value }),
+    onScopeChange: (value: DashboardImageScope) => updateImageView({ scope: value }),
     pageIndex: pageIndex + 1,
     pageIndexZeroBased: pageIndex,
     pageSize,

--- a/src/features/dashboard/hooks/useImagesTable.tsx
+++ b/src/features/dashboard/hooks/useImagesTable.tsx
@@ -4,7 +4,7 @@ import type {
   RowSelectionState,
   Table as TableInstance,
 } from '@tanstack/react-table'
-import type { AlbumImageListItem } from '@/lib/storage/types'
+import type { AlbumImageListItem, AlbumRecord } from '@/lib/storage/types'
 import {
   getCoreRowModel,
   useReactTable,
@@ -14,12 +14,15 @@ import { LazyImage } from '@/components/LazyImage'
 import { Checkbox } from '@/components/ui/checkbox'
 import { ImageActionsDropdownMenu } from '@/features/dashboard/components/ImageActionsMenu'
 import { applyShiftRangeSelection } from '@/features/dashboard/lib/shiftRangeSelection'
+import { formatAlbumPath } from '@/lib/storage/albumLabel'
 import { formatBytes } from '@/lib/storage/format'
 
 interface UseImagesTableOptions {
   images: AlbumImageListItem[]
   pageIndex: number
   pageSize: number
+  albums: AlbumRecord[]
+  showAlbumColumn: boolean
   onRenameImage: (objectKey: string) => void
   onMoveImage: (objectKey: string) => void
   onDeleteImage: (objectKey: string) => void
@@ -51,6 +54,8 @@ export function useImagesTable(options: UseImagesTableOptions) {
     images,
     pageIndex,
     pageSize,
+    albums,
+    showAlbumColumn,
     onRenameImage,
     onMoveImage,
     onDeleteImage,
@@ -114,109 +119,126 @@ export function useImagesTable(options: UseImagesTableOptions) {
     lastAnchorRowIdRef.current = input.rowId
   }, [])
 
-  const columns = useMemo<ColumnDef<AlbumImageListItem>[]>(() => [
-    {
-      id: 'select',
-      header: ({ table }) => (
-        <Checkbox
-          aria-label="Select all rows"
-          checked={table.getIsSomePageRowsSelected() ? 'indeterminate' : table.getIsAllPageRowsSelected()}
-          onCheckedChange={checked => table.toggleAllPageRowsSelected(checked === true)}
-        />
-      ),
-      cell: ({ row, table }) => (
-        <Checkbox
-          aria-label={`Select ${row.original.name}`}
-          checked={row.getIsSelected()}
-          onClick={(event_) => {
-            event_.preventDefault()
-            toggleRowSelection({
-              rowId: row.id,
-              shiftKey: event_.shiftKey,
-              table,
-            })
-          }}
-        />
-      ),
-      enableSorting: false,
-    },
-    {
-      id: 'preview',
-      header: 'Preview',
-      cell: ({ row }) => (
-        row.original.thumbnailUrl !== null
-          ? (
-              <LazyImage
-                src={row.original.thumbnailUrl}
-                alt={row.original.name}
-                className="h-12 w-12 rounded-md border object-cover"
-              />
-            )
-          : (
-              <div className="flex h-12 w-12 items-center justify-center rounded-md border text-[10px] text-muted-foreground">
-                URL ERR
-              </div>
-            )
-      ),
-      enableSorting: false,
-    },
-    {
-      accessorKey: 'name',
-      header: 'Name',
-      cell: ({ row }) => (
-        <div className="max-w-60 truncate font-medium">{row.original.name}</div>
-      ),
-      enableSorting: false,
-    },
-    {
-      accessorKey: 'sizeBytes',
-      header: 'Size',
-      cell: ({ row }) => formatBytes(row.original.sizeBytes),
-      enableSorting: false,
-    },
-    {
-      id: 'dimensions',
-      header: 'Dimensions',
-      cell: ({ row }) => {
-        const { width, height } = row.original
-        if (typeof width !== 'number' || typeof height !== 'number') {
-          return <span className="text-muted-foreground">Unknown</span>
-        }
-        return `${width} × ${height}`
-      },
-      enableSorting: false,
-    },
-    {
-      id: 'type',
-      header: 'Type',
-      cell: ({ row }) =>
-        row.original.publicUrl?.split('.').pop()?.toUpperCase()
-        ?? row.original.mime.split('/').pop()?.toUpperCase()
-        ?? 'Unknown',
-      enableSorting: false,
-    },
-    {
-      accessorKey: 'createdAt',
-      header: 'Uploaded',
-      cell: ({ row }) => new Date(row.original.createdAt).toLocaleString(),
-      enableSorting: false,
-    },
-    {
-      id: 'actions',
-      header: 'Actions',
-      enableSorting: false,
-      cell: ({ row }) => (
-        <div className="flex justify-end">
-          <ImageActionsDropdownMenu
-            image={row.original}
-            onRenameImage={onRenameImage}
-            onMoveImage={onMoveImage}
-            onDeleteImage={onDeleteImage}
+  const columns = useMemo<ColumnDef<AlbumImageListItem>[]>(() => {
+    const albumById = new Map(albums.map(album => [album.id, album]))
+    const imageColumns: ColumnDef<AlbumImageListItem>[] = [
+      {
+        id: 'select',
+        header: ({ table }) => (
+          <Checkbox
+            aria-label="Select all rows"
+            checked={table.getIsSomePageRowsSelected() ? 'indeterminate' : table.getIsAllPageRowsSelected()}
+            onCheckedChange={checked => table.toggleAllPageRowsSelected(checked === true)}
           />
-        </div>
-      ),
-    },
-  ], [onDeleteImage, onMoveImage, onRenameImage, toggleRowSelection])
+        ),
+        cell: ({ row, table }) => (
+          <Checkbox
+            aria-label={`Select ${row.original.name}`}
+            checked={row.getIsSelected()}
+            onClick={(event_) => {
+              event_.preventDefault()
+              toggleRowSelection({
+                rowId: row.id,
+                shiftKey: event_.shiftKey,
+                table,
+              })
+            }}
+          />
+        ),
+        enableSorting: false,
+      },
+      {
+        id: 'preview',
+        header: 'Preview',
+        cell: ({ row }) => (
+          row.original.thumbnailUrl !== null
+            ? (
+                <LazyImage
+                  src={row.original.thumbnailUrl}
+                  alt={row.original.name}
+                  className="h-12 w-12 rounded-md border object-cover"
+                />
+              )
+            : (
+                <div className="flex h-12 w-12 items-center justify-center rounded-md border text-[10px] text-muted-foreground">
+                  URL ERR
+                </div>
+              )
+        ),
+        enableSorting: false,
+      },
+      {
+        accessorKey: 'name',
+        header: 'Name',
+        cell: ({ row }) => (
+          <div className="max-w-60 truncate font-medium">{row.original.name}</div>
+        ),
+        enableSorting: false,
+      },
+      ...(showAlbumColumn
+        ? [{
+          id: 'album',
+          header: 'Album',
+          cell: ({ row }) => {
+            const album = albumById.get(row.original.albumId)
+            return album === undefined
+              ? <span className="text-muted-foreground">Unknown</span>
+              : <div className="max-w-52 truncate">{formatAlbumPath(album, albums)}</div>
+          },
+          enableSorting: false,
+        } satisfies ColumnDef<AlbumImageListItem>]
+        : []),
+      {
+        accessorKey: 'sizeBytes',
+        header: 'Size',
+        cell: ({ row }) => formatBytes(row.original.sizeBytes),
+        enableSorting: false,
+      },
+      {
+        id: 'dimensions',
+        header: 'Dimensions',
+        cell: ({ row }) => {
+          const { width, height } = row.original
+          if (typeof width !== 'number' || typeof height !== 'number') {
+            return <span className="text-muted-foreground">Unknown</span>
+          }
+          return `${width} × ${height}`
+        },
+        enableSorting: false,
+      },
+      {
+        id: 'type',
+        header: 'Type',
+        cell: ({ row }) =>
+          row.original.publicUrl?.split('.').pop()?.toUpperCase()
+          ?? row.original.mime.split('/').pop()?.toUpperCase()
+          ?? 'Unknown',
+        enableSorting: false,
+      },
+      {
+        accessorKey: 'createdAt',
+        header: 'Uploaded',
+        cell: ({ row }) => new Date(row.original.createdAt).toLocaleString(),
+        enableSorting: false,
+      },
+      {
+        id: 'actions',
+        header: 'Actions',
+        enableSorting: false,
+        cell: ({ row }) => (
+          <div className="flex justify-end">
+            <ImageActionsDropdownMenu
+              image={row.original}
+              onRenameImage={onRenameImage}
+              onMoveImage={onMoveImage}
+              onDeleteImage={onDeleteImage}
+            />
+          </div>
+        ),
+      },
+    ]
+    return imageColumns
+  }, [albums, onDeleteImage, onMoveImage, onRenameImage, showAlbumColumn, toggleRowSelection])
 
   const pagination = useMemo<PaginationState>(() => ({
     pageIndex,

--- a/src/features/dashboard/hooks/useUpload.ts
+++ b/src/features/dashboard/hooks/useUpload.ts
@@ -2,7 +2,9 @@ import type { AlbumImageRecord, ImageRecord } from '@/lib/storage/types'
 import { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { uploadImageFn } from '@/functions/images'
+import { isHostedSourceUploadCompatible } from '@/lib/images/hostedSourceCompatibility'
 import { transformImageFile } from '@/lib/img'
+import { shouldKeepOriginalImage } from '@/lib/img/output'
 import { withoutExtension } from '@/lib/storage/format'
 
 // Image transforms are intentionally serialized to bound decoded bitmap memory.
@@ -91,7 +93,14 @@ export function useUpload(options: UseUploadOptions) {
 
         try {
           const transformed = await transformImageFile(file, 'webp')
-          const hostedFile = transformed.preservedOriginal
+          const sourceIsHostCompatible = isHostedSourceUploadCompatible(file)
+          const keepSource = !transformed.resizedToPixelBudget
+            && sourceIsHostCompatible
+            && (
+              transformed.preservedOriginal
+              || shouldKeepOriginalImage({ originalSize: file.size, outputSize: transformed.blob.size })
+            )
+          const hostedFile = keepSource
             ? file
             : new File(
                 [transformed.blob],

--- a/src/features/dashboard/lib/urlState.ts
+++ b/src/features/dashboard/lib/urlState.ts
@@ -1,10 +1,49 @@
+import type { ImageDateFilter, ImageFormatFilter, ImageListSort, ImageOrientationFilter, ImageResolutionFilter } from '@/lib/storage/types'
+import { IMAGE_LIST_SORTS } from '@/lib/storage/types'
+
 export const DASHBOARD_PAGE_SIZES = [25, 50, 100, 200] as const
+export const DASHBOARD_IMAGE_FORMATS = ['all', 'avif', 'bmp', 'gif', 'jpeg', 'png', 'webp'] as const
+export const DASHBOARD_IMAGE_ORIENTATIONS = ['all', 'landscape', 'portrait', 'square'] as const
+export const DASHBOARD_IMAGE_DATES = ['all', 'today', '7d', '30d', '1y'] as const
+export const DASHBOARD_IMAGE_RESOLUTIONS = ['all', 'under-2mp', '2-12mp', '12-24mp', 'over-24mp'] as const
+export const DASHBOARD_IMAGE_SCOPES = ['album', 'all'] as const
+export type DashboardImageScope = typeof DASHBOARD_IMAGE_SCOPES[number]
 
 export interface DashboardUrlState {
   album?: string
   q?: string
   page: number
   pageSize: number
+  sort: ImageListSort
+  format: ImageFormatFilter
+  orientation: ImageOrientationFilter
+  date: ImageDateFilter
+  resolution: ImageResolutionFilter
+  scope: DashboardImageScope
+}
+
+export function isDashboardImageSort(value: unknown): value is ImageListSort {
+  return IMAGE_LIST_SORTS.includes(value as ImageListSort)
+}
+
+export function isDashboardImageFormat(value: unknown): value is ImageFormatFilter {
+  return DASHBOARD_IMAGE_FORMATS.includes(value as ImageFormatFilter)
+}
+
+export function isDashboardImageOrientation(value: unknown): value is ImageOrientationFilter {
+  return DASHBOARD_IMAGE_ORIENTATIONS.includes(value as ImageOrientationFilter)
+}
+
+export function isDashboardImageDate(value: unknown): value is ImageDateFilter {
+  return DASHBOARD_IMAGE_DATES.includes(value as ImageDateFilter)
+}
+
+export function isDashboardImageResolution(value: unknown): value is ImageResolutionFilter {
+  return DASHBOARD_IMAGE_RESOLUTIONS.includes(value as ImageResolutionFilter)
+}
+
+export function isDashboardImageScope(value: unknown): value is DashboardImageScope {
+  return DASHBOARD_IMAGE_SCOPES.includes(value as DashboardImageScope)
 }
 
 /**

--- a/src/features/home/components/ResultRow.tsx
+++ b/src/features/home/components/ResultRow.tsx
@@ -73,6 +73,7 @@ export function ResultRow({
   const compressedSize = item.outputSize
   const isCompressed = item.status === 'compressed' && compressedSize !== null
   const isOutputAvailable = (item.status === 'compressed' || item.status === 'original') && item.outputFile !== null
+  const isUploadEligible = isOutputAvailable && item.uploadFile !== null && item.thumbnailFile !== null
   const savedPercent = isCompressed && item.originalSize > 0
     ? ((item.originalSize - compressedSize) / item.originalSize) * 100
     : 0
@@ -89,7 +90,7 @@ export function ResultRow({
             <Checkbox
               aria-label={`Select ${item.originalName}`}
               checked={isSelected}
-              disabled={selectionDisabled || !isOutputAvailable}
+              disabled={selectionDisabled || !isUploadEligible}
               onCheckedChange={checked => onToggleSelected(checked === true)}
               className="h-5 w-5 rounded-md"
             />
@@ -177,11 +178,6 @@ export function ResultRow({
 
             {sizeLabel !== null && (
               <span className={`wrap-break-word ${sizeLabelClass}`}>{sizeLabel}</span>
-            )}
-            {item.status === 'original' && (
-              <span className="wrap-break-word text-amber-700 dark:text-amber-400">
-                Animation preserved without flattening frames.
-              </span>
             )}
           </div>
 

--- a/src/features/home/components/UploadSelectedDialog.tsx
+++ b/src/features/home/components/UploadSelectedDialog.tsx
@@ -4,6 +4,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Label } from '@/components/ui/label'
 import { LoadingButton } from '@/components/ui/loading-button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { formatAlbumPath } from '@/lib/storage/albumLabel'
 
 interface UploadSelectedDialogProps {
   open: boolean
@@ -56,7 +57,7 @@ export function UploadSelectedDialog({
             </SelectTrigger>
             <SelectContent>
               {albums.map(album => (
-                <SelectItem key={album.id} value={album.id}>{album.name}</SelectItem>
+                <SelectItem key={album.id} value={album.id}>{formatAlbumPath(album, albums)}</SelectItem>
               ))}
             </SelectContent>
           </Select>

--- a/src/features/home/hooks/useCompressedDownloads.ts
+++ b/src/features/home/hooks/useCompressedDownloads.ts
@@ -3,6 +3,7 @@ import JSZip from 'jszip'
 import { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { getZipInputBytes, MAX_ZIP_INPUT_BYTES } from '@/features/home/lib/memoryBudget'
+import { uniqueDownloadNames } from '@/features/home/lib/uniqueDownloadNames'
 import { getHumanReadableFileSize } from '@/utils/converter'
 
 /**
@@ -57,8 +58,9 @@ export function useCompressedDownloads(items: readonly HomeProcessedItem[]) {
         }
 
         const zip = new JSZip()
-        for (const file of outputFiles) {
-          zip.file(file.name, file)
+        const entryNames = uniqueDownloadNames(outputFiles.map(file => file.name))
+        for (const [index, file] of outputFiles.entries()) {
+          zip.file(entryNames[index] ?? file.name, file)
         }
 
         const zipBlob = await zip.generateAsync({ type: 'blob', compression: 'STORE', streamFiles: true })

--- a/src/features/home/hooks/useImageTransformQueue.ts
+++ b/src/features/home/hooks/useImageTransformQueue.ts
@@ -7,7 +7,9 @@ import {
   MAX_QUEUE_SOURCE_BYTES,
   selectWithinQueueBudget,
 } from '@/features/home/lib/memoryBudget'
+import { isHostedSourceUploadCompatible } from '@/lib/images/hostedSourceCompatibility'
 import { checkImage, normalizeTransformError, transformImageFile } from '@/lib/img'
+import { shouldKeepOriginalImage } from '@/lib/img/output'
 import { normalizeImageMime } from '@/lib/storage/format'
 import { getHumanReadableFileSize } from '@/utils/converter'
 
@@ -55,20 +57,36 @@ export function useImageTransformQueue() {
   const itemsRef = useRef<HomeProcessedItem[]>([])
   const isTransformingRef = useRef(false)
   const queueSourceBytesRef = useRef(0)
+  const objectUrlsRef = useRef(new Set<string>())
+  const isMountedRef = useRef(true)
 
   useEffect(() => {
     itemsRef.current = items
   }, [items])
 
   useEffect(() => {
+    const objectUrls = objectUrlsRef.current
+    isMountedRef.current = true
     return () => {
-      for (const item of itemsRef.current) {
-        URL.revokeObjectURL(item.originalPreviewUrl)
-        if (item.thumbnailPreviewUrl !== null) {
-          URL.revokeObjectURL(item.thumbnailPreviewUrl)
-        }
+      isMountedRef.current = false
+      for (const url of objectUrls) {
+        URL.revokeObjectURL(url)
       }
+      objectUrls.clear()
     }
+  }, [])
+
+  const createTrackedObjectUrl = useCallback((blob: Blob): string => {
+    const url = URL.createObjectURL(blob)
+    objectUrlsRef.current.add(url)
+    return url
+  }, [])
+
+  const revokeTrackedObjectUrl = useCallback((url: string | null): void => {
+    if (url === null || !objectUrlsRef.current.delete(url)) {
+      return
+    }
+    URL.revokeObjectURL(url)
   }, [])
 
   const patchItem = useCallback((id: string, patch: Partial<HomeProcessedItem>) => {
@@ -76,7 +94,7 @@ export function useImageTransformQueue() {
   }, [])
 
   const addImages = useCallback((files: File[]) => {
-    const validFiles: Array<{ file: File, format: SupportedFormat, name: string, originalSize: number, size: number }> = []
+    const validFiles: Array<{ file: File, format: string, name: string, originalSize: number, size: number }> = []
 
     for (const file of files) {
       try {
@@ -100,13 +118,14 @@ export function useImageTransformQueue() {
       originalFile: file,
       originalName: name,
       originalSize,
-      originalPreviewUrl: URL.createObjectURL(file),
+      originalPreviewUrl: createTrackedObjectUrl(file),
       thumbnailPreviewUrl: null,
       originalFormat: format,
       targetFormat,
       outputBlob: null,
       outputFile: null,
       outputSize: null,
+      uploadFile: null,
       width: null,
       height: null,
       sourceWidth: null,
@@ -141,21 +160,19 @@ export function useImageTransformQueue() {
       setItems(nextItems)
       setCompressionState('idle')
     }
-  }, [retainOriginal, targetFormat])
+  }, [createTrackedObjectUrl, retainOriginal, targetFormat])
 
   const removeItem = useCallback((id: string) => {
     const target = itemsRef.current.find(item => item.id === id)
     if (target) {
       queueSourceBytesRef.current = Math.max(0, queueSourceBytesRef.current - target.originalSize)
-      URL.revokeObjectURL(target.originalPreviewUrl)
-      if (target.thumbnailPreviewUrl !== null) {
-        URL.revokeObjectURL(target.thumbnailPreviewUrl)
-      }
+      revokeTrackedObjectUrl(target.originalPreviewUrl)
+      revokeTrackedObjectUrl(target.thumbnailPreviewUrl)
     }
     const nextItems = itemsRef.current.filter(item => item.id !== id)
     itemsRef.current = nextItems
     setItems(nextItems)
-  }, [])
+  }, [revokeTrackedObjectUrl])
 
   const transformOne = useCallback(async (item: HomeProcessedItem): Promise<HomeProcessedItem> => {
     const transformed = await transformImageFile(
@@ -177,10 +194,10 @@ export function useImageTransformQueue() {
       blob: thumbnailBlob,
       originalName: item.originalName,
     })
-    const thumbnailPreviewUrl = URL.createObjectURL(thumbnailBlob)
-    if (item.thumbnailPreviewUrl !== null) {
-      URL.revokeObjectURL(item.thumbnailPreviewUrl)
-    }
+    const thumbnailPreviewUrl = isMountedRef.current
+      ? createTrackedObjectUrl(thumbnailBlob)
+      : null
+    revokeTrackedObjectUrl(item.thumbnailPreviewUrl)
     const derivativePatch = {
       sourceWidth,
       sourceHeight,
@@ -194,6 +211,19 @@ export function useImageTransformQueue() {
       transformNotice: transformed.sourceNotice,
     }
     if (transformed.preservedOriginal) {
+      const compressedFile = toCompressedFile({
+        blob,
+        originalName: item.originalName,
+        targetFormat,
+      })
+      const canHostOriginal = !transformed.resizedToPixelBudget
+        && isHostedSourceUploadCompatible(item.originalFile)
+      const notices = [
+        transformed.sourceNotice,
+        canHostOriginal
+          ? 'Animation was kept unchanged.'
+          : 'Animation was kept for download; a static converted frame will be used for hosting compatibility.',
+      ].filter((notice): notice is string => notice !== null)
       return {
         ...item,
         ...derivativePatch,
@@ -201,10 +231,48 @@ export function useImageTransformQueue() {
         outputBlob: item.originalFile,
         outputFile: item.originalFile,
         outputSize: item.originalSize,
-        width,
-        height,
+        uploadFile: canHostOriginal ? item.originalFile : compressedFile,
+        width: canHostOriginal ? sourceWidth : width,
+        height: canHostOriginal ? sourceHeight : height,
         status: 'original',
-        transformError: 'Animated images are uploaded unchanged.',
+        transformError: null,
+        transformNotice: notices.join(' '),
+        uploadStatus: 'idle',
+        uploadError: null,
+        uploadedUrl: null,
+        uploadedObjectKey: null,
+        uploadedAlbumId: null,
+      }
+    }
+    if (shouldKeepOriginalImage({
+      originalSize: item.originalSize,
+      outputSize: blob.size,
+    })) {
+      const compressedFile = toCompressedFile({
+        blob,
+        originalName: item.originalName,
+        targetFormat,
+      })
+      const canHostOriginal = !transformed.resizedToPixelBudget
+        && isHostedSourceUploadCompatible(item.originalFile)
+      const uploadFile = canHostOriginal
+        ? item.originalFile
+        : compressedFile
+      return {
+        ...item,
+        ...derivativePatch,
+        targetFormat,
+        outputBlob: item.originalFile,
+        outputFile: item.originalFile,
+        outputSize: item.originalSize,
+        uploadFile,
+        width: canHostOriginal ? sourceWidth : width,
+        height: canHostOriginal ? sourceHeight : height,
+        status: 'original',
+        transformError: null,
+        transformNotice: canHostOriginal
+          ? 'Original kept because conversion did not reduce the file size.'
+          : 'Original kept for download; the resized or converted file will be used for hosting compatibility.',
         uploadStatus: 'idle',
         uploadError: null,
         uploadedUrl: null,
@@ -225,6 +293,7 @@ export function useImageTransformQueue() {
       outputBlob: blob,
       outputFile: compressedFile,
       outputSize: blob.size,
+      uploadFile: compressedFile,
       width,
       height,
       status: 'compressed',
@@ -235,7 +304,7 @@ export function useImageTransformQueue() {
       uploadedObjectKey: null,
       uploadedAlbumId: null,
     }
-  }, [quality, retainOriginal, targetFormat, useManualQuality])
+  }, [createTrackedObjectUrl, quality, retainOriginal, revokeTrackedObjectUrl, targetFormat, useManualQuality])
 
   const transformAll = useCallback(async () => {
     if (isTransformingRef.current || itemsRef.current.length === 0) {
@@ -255,6 +324,9 @@ export function useImageTransformQueue() {
     try {
       setCompressionState('compressing')
       setCompressedCount(0)
+
+      // Let React commit the pending state before cloning a large File into the worker.
+      await new Promise<void>(resolve => setTimeout(resolve, 0))
 
       let succeeded = 0
       let failed = 0
@@ -279,7 +351,7 @@ export function useImageTransformQueue() {
         catch (error) {
           const normalized = normalizeTransformError(error)
           if (current.thumbnailPreviewUrl !== null) {
-            URL.revokeObjectURL(current.thumbnailPreviewUrl)
+            revokeTrackedObjectUrl(current.thumbnailPreviewUrl)
           }
           patchItem(current.id, {
             status: 'error',
@@ -287,6 +359,7 @@ export function useImageTransformQueue() {
             outputBlob: null,
             outputFile: null,
             outputSize: null,
+            uploadFile: null,
             width: null,
             height: null,
             sourceWidth: null,
@@ -314,7 +387,7 @@ export function useImageTransformQueue() {
       if (succeeded > 0 && failed === 0) {
         if (retainedOriginals > 0) {
           toast.warning('Some original files were kept', {
-            description: `${retainedOriginals} animated image(s) were preserved to avoid flattening frames.`,
+            description: `${retainedOriginals} image(s) kept their original file because conversion was not beneficial or would lose animation.`,
           })
         }
         else {
@@ -339,7 +412,7 @@ export function useImageTransformQueue() {
       isTransformingRef.current = false
       setIsTransforming(false)
     }
-  }, [patchItem, transformOne])
+  }, [patchItem, revokeTrackedObjectUrl, transformOne])
 
   const retryTransform = useCallback(async (id: string) => {
     if (isTransformingRef.current) {
@@ -360,6 +433,7 @@ export function useImageTransformQueue() {
     })
 
     try {
+      await new Promise<void>(resolve => setTimeout(resolve, 0))
       const transformed = await transformOne(target)
       patchItem(id, transformed)
       toast.success(`Recompressed ${target.originalName}`)
@@ -368,7 +442,7 @@ export function useImageTransformQueue() {
     catch (error) {
       const normalized = normalizeTransformError(error)
       if (target.thumbnailPreviewUrl !== null) {
-        URL.revokeObjectURL(target.thumbnailPreviewUrl)
+        revokeTrackedObjectUrl(target.thumbnailPreviewUrl)
       }
       patchItem(id, {
         status: 'error',
@@ -376,6 +450,7 @@ export function useImageTransformQueue() {
         outputBlob: null,
         outputFile: null,
         outputSize: null,
+        uploadFile: null,
         width: null,
         height: null,
         sourceWidth: null,
@@ -402,7 +477,7 @@ export function useImageTransformQueue() {
       isTransformingRef.current = false
       setIsTransforming(false)
     }
-  }, [patchItem, transformOne])
+  }, [patchItem, revokeTrackedObjectUrl, transformOne])
 
   return {
     items,

--- a/src/features/home/hooks/useSelection.ts
+++ b/src/features/home/hooks/useSelection.ts
@@ -4,7 +4,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 function isSelectable(item: HomeProcessedItem): boolean {
   return (
     (item.status === 'compressed' || item.status === 'original')
-    && item.outputFile !== null
+    && item.uploadFile !== null
+    && item.thumbnailFile !== null
   )
 }
 

--- a/src/features/home/hooks/useUploadSelected.ts
+++ b/src/features/home/hooks/useUploadSelected.ts
@@ -248,6 +248,7 @@ export function useUploadSelected(
       selectedIds.has(item.id)
       && (item.status === 'compressed' || item.status === 'original')
       && item.outputFile !== null
+      && item.uploadFile !== null
       && item.thumbnailFile !== null
       && item.uploadStatus !== 'uploaded'
     ))
@@ -280,10 +281,10 @@ export function useUploadSelected(
         candidates,
         async (item) => {
           try {
-            const file = item.outputFile
+            const file = item.uploadFile
 
             if (!file) {
-              throw new Error('Missing processed output file')
+              throw new Error('Missing host-compatible output file')
             }
             if (!item.thumbnailFile) {
               throw new Error('Missing WebP thumbnail file')
@@ -296,13 +297,14 @@ export function useUploadSelected(
             formData.set('source', 'index-compressed')
             formData.set('originalName', item.originalName)
 
-            if (item.retainOriginal && item.status !== 'original') {
+            const retainsSeparateOriginal = item.retainOriginal && file !== item.originalFile
+            if (retainsSeparateOriginal) {
               formData.set('original', item.originalFile)
             }
 
             const uploadAssetBytes = file.size
               + item.thumbnailFile.size
-              + (item.retainOriginal && item.status !== 'original' ? item.originalFile.size : 0)
+              + (retainsSeparateOriginal ? item.originalFile.size : 0)
             if (uploadAssetBytes > MAX_UPLOAD_ASSET_BYTES) {
               throw new Error('Combined hosted image, thumbnail, and original exceed 95 MiB')
             }

--- a/src/features/home/lib/uniqueDownloadNames.test.ts
+++ b/src/features/home/lib/uniqueDownloadNames.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { uniqueDownloadNames } from './uniqueDownloadNames'
+
+describe('uniqueDownloadNames', () => {
+  it('suffixes duplicate ZIP entries without changing their extensions', () => {
+    expect(uniqueDownloadNames(['photo.webp', 'photo.webp', 'PHOTO.webp', 'notes'])).toEqual([
+      'photo.webp',
+      'photo (2).webp',
+      'PHOTO (3).webp',
+      'notes',
+    ])
+  })
+})

--- a/src/features/home/lib/uniqueDownloadNames.ts
+++ b/src/features/home/lib/uniqueDownloadNames.ts
@@ -1,0 +1,26 @@
+function splitExtension(name: string): { base: string, extension: string } {
+  const lastDot = name.lastIndexOf('.')
+  if (lastDot <= 0) {
+    return { base: name, extension: '' }
+  }
+  return {
+    base: name.slice(0, lastDot),
+    extension: name.slice(lastDot),
+  }
+}
+
+/** Returns stable, case-insensitively unique names for ZIP entries. */
+export function uniqueDownloadNames(names: readonly string[]): string[] {
+  const used = new Set<string>()
+  return names.map((name) => {
+    const { base, extension } = splitExtension(name)
+    let candidate = name
+    let suffix = 2
+    while (used.has(candidate.toLowerCase())) {
+      candidate = `${base} (${suffix})${extension}`
+      suffix += 1
+    }
+    used.add(candidate.toLowerCase())
+    return candidate
+  })
+}

--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -34,6 +34,8 @@ export interface HomeProcessedItem {
   outputBlob: Blob | null
   outputFile: File | null
   outputSize: number | null
+  /** Hosted derivative; may differ from the download output when the source is not host-compatible. */
+  uploadFile: File | null
   width: number | null
   height: number | null
   sourceWidth: number | null

--- a/src/functions/images.ts
+++ b/src/functions/images.ts
@@ -90,7 +90,7 @@ export const listImagesFn = createServerFn({ method: 'POST' })
     await reconcilePendingUploads(r2).catch((error) => {
       console.error('[listImagesFn] Failed to reconcile pending uploads:', error)
     })
-    if (!(await albumExists(db, data.albumId))) {
+    if (!data.allAlbums && !(await albumExists(db, data.albumId))) {
       throw new Error('Album not found')
     }
 
@@ -100,6 +100,11 @@ export const listImagesFn = createServerFn({ method: 'POST' })
       pageSize: data.pageSize,
       sort: data.sort,
       query: data.query,
+      format: data.format,
+      orientation: data.orientation,
+      date: data.date,
+      resolution: data.resolution,
+      allAlbums: data.allAlbums,
     })
 
     let imageUrlError: string | null = null
@@ -127,6 +132,9 @@ export const listImagesFn = createServerFn({ method: 'POST' })
         thumbnailUrl: publicDomain !== null
           ? buildPublicImageUrl(image.thumbnail?.objectKey ?? image.objectKey, publicDomain)
           : null,
+        originalDownloadUrl: image.original === null
+          ? null
+          : `/api/images/original?objectKey=${encodeURIComponent(image.objectKey)}`,
       }
     })
 
@@ -283,6 +291,7 @@ export const uploadImageFn = createServerFn({ method: 'POST' })
       height: image.height,
       createdAt: image.createdAt,
       thumbnail: image.thumbnail ?? null,
+      original: image.original ?? null,
     }
 
     let metadataCommitted = false

--- a/src/lib/db/cursor.test.ts
+++ b/src/lib/db/cursor.test.ts
@@ -1,0 +1,18 @@
+import { Buffer } from 'node:buffer'
+import { describe, expect, it } from 'vitest'
+import { decodeImageListCursor, encodeImageListCursor } from './cursor'
+
+describe('image list cursor', () => {
+  it('round-trips numeric and string sort values', () => {
+    const numeric = { sort: 'sizeBytes-desc' as const, value: 42_000, id: 'image-a' }
+    const text = { sort: 'name-asc' as const, value: 'holiday', id: 'image-b' }
+
+    expect(decodeImageListCursor(encodeImageListCursor(numeric))).toEqual(numeric)
+    expect(decodeImageListCursor(encodeImageListCursor(text))).toEqual(text)
+  })
+
+  it('rejects cursors with unsupported sort values', () => {
+    const malformed = Buffer.from(JSON.stringify({ sort: 'random', value: 1, id: 'image-a' })).toString('base64url')
+    expect(() => decodeImageListCursor(malformed)).toThrow('Invalid pagination cursor')
+  })
+})

--- a/src/lib/db/cursor.ts
+++ b/src/lib/db/cursor.ts
@@ -1,12 +1,15 @@
+import type { ImageListSort } from '@/lib/storage/types'
 import { Buffer } from 'node:buffer'
+import { IMAGE_LIST_SORTS } from '@/lib/storage/types'
 
 export interface ImageListCursor {
-  createdAt: number
+  sort: ImageListSort
+  value: number | string
   id: string
 }
 
 /**
- * Encodes an opaque keyset cursor for descending `(created_at, id)` pagination.
+ * Encodes an opaque keyset cursor for the selected stable image ordering.
  */
 export function encodeImageListCursor(cursor: ImageListCursor): string {
   return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url')
@@ -22,12 +25,19 @@ export function decodeImageListCursor(value: string): ImageListCursor {
     if (typeof parsed.id !== 'string' || parsed.id.length === 0) {
       throw new TypeError('Invalid image cursor id')
     }
-    if (typeof parsed.createdAt !== 'number' || !Number.isFinite(parsed.createdAt)) {
-      throw new TypeError('Invalid image cursor timestamp')
+    if (!IMAGE_LIST_SORTS.includes(parsed.sort as ImageListSort)) {
+      throw new TypeError('Invalid image cursor sort')
+    }
+    if (
+      (typeof parsed.value !== 'number' || !Number.isFinite(parsed.value))
+      && typeof parsed.value !== 'string'
+    ) {
+      throw new TypeError('Invalid image cursor value')
     }
     return {
       id: parsed.id,
-      createdAt: Math.trunc(parsed.createdAt),
+      sort: parsed.sort as ImageListSort,
+      value: typeof parsed.value === 'number' ? Math.trunc(parsed.value) : parsed.value,
     }
   }
   catch {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,4 +1,5 @@
 import type { AnySQLiteColumn } from 'drizzle-orm/sqlite-core'
+import { sql } from 'drizzle-orm'
 import { index, integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core'
 
 export const albumsTable = sqliteTable('albums', {
@@ -13,6 +14,7 @@ export const albumsTable = sqliteTable('albums', {
   updatedAt: integer('updated_at').notNull(),
 }, table => [
   index('idx_albums_parent_id').on(table.parentId),
+  uniqueIndex('ux_albums_single_default').on(table.isDefault).where(sql`${table.isDefault} = 1`),
 ])
 
 export const imagesTable = sqliteTable('images', {
@@ -52,6 +54,12 @@ export const imagesTable = sqliteTable('images', {
 }, table => [
   index('idx_images_album_created_desc').on(table.albumId, table.createdAt, table.id),
   index('idx_images_album_name_lower').on(table.albumId, table.nameLower),
+  index('idx_images_album_name_sort').on(table.albumId, table.nameLower, table.id),
+  index('idx_images_album_bytes_sort').on(table.albumId, table.bytes, table.id),
+  index('idx_images_album_ext_sort').on(table.albumId, table.ext, table.id),
+  index('idx_images_name_sort').on(table.nameLower, table.id),
+  index('idx_images_bytes_sort').on(table.bytes, table.id),
+  index('idx_images_ext_sort').on(table.ext, table.id),
   index('idx_images_created_desc').on(table.createdAt, table.id),
   index('idx_images_pending_cleanup').on(table.deletedAt, table.id),
   uniqueIndex('ux_images_original_object_key').on(table.originalObjectKey),

--- a/src/lib/images/download.test.ts
+++ b/src/lib/images/download.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { buildAttachmentDisposition } from './download'
+
+describe('buildAttachmentDisposition', () => {
+  it('removes header control characters and preserves a UTF-8 filename', () => {
+    expect(buildAttachmentDisposition('猫\r\nphoto.raw')).toBe(
+      'attachment; filename="_photo.raw"; filename*=UTF-8\'\'%E7%8C%ABphoto.raw',
+    )
+  })
+
+  it('percent-encodes RFC 5987 delimiter characters', () => {
+    expect(buildAttachmentDisposition('it\'s (final).raw'))
+      .toContain('filename*=UTF-8\'\'it%27s%20%28final%29.raw')
+  })
+})

--- a/src/lib/images/download.ts
+++ b/src/lib/images/download.ts
@@ -1,0 +1,10 @@
+/** Builds a safe attachment header for a user-supplied source filename. */
+export function buildAttachmentDisposition(filename: string): string {
+  const safeUnicode = filename.replaceAll(/[\r\n]/g, '').trim() || 'original-image'
+  const asciiFallback = safeUnicode
+    .replaceAll(/[^\x20-\x7E]/g, '_')
+    .replaceAll(/["\\]/g, '_')
+  const encodedUnicode = encodeURIComponent(safeUnicode)
+    .replaceAll(/[!'()*]/g, character => `%${character.charCodeAt(0).toString(16).toUpperCase()}`)
+  return `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodedUnicode}`
+}

--- a/src/lib/images/hostedSourceCompatibility.test.ts
+++ b/src/lib/images/hostedSourceCompatibility.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { isHostedSourceUploadCompatible } from './hostedSourceCompatibility'
+
+describe('isHostedSourceUploadCompatible', () => {
+  it('accepts supported hosted sources and rejects opaque source formats', () => {
+    expect(isHostedSourceUploadCompatible(new File(['image'], 'image.png', { type: 'image/png' }))).toBe(true)
+    expect(isHostedSourceUploadCompatible(new File(['raw'], 'image.raw', { type: 'application/octet-stream' }))).toBe(false)
+  })
+})

--- a/src/lib/images/hostedSourceCompatibility.test.ts
+++ b/src/lib/images/hostedSourceCompatibility.test.ts
@@ -4,6 +4,9 @@ import { isHostedSourceUploadCompatible } from './hostedSourceCompatibility'
 describe('isHostedSourceUploadCompatible', () => {
   it('accepts supported hosted sources and rejects opaque source formats', () => {
     expect(isHostedSourceUploadCompatible(new File(['image'], 'image.png', { type: 'image/png' }))).toBe(true)
+    expect(isHostedSourceUploadCompatible(new File(['image'], 'image.png', { type: 'image/apng' }))).toBe(true)
+    expect(isHostedSourceUploadCompatible(new File(['image'], 'image.jpg', { type: 'image/jpg' }))).toBe(true)
+    expect(isHostedSourceUploadCompatible(new File(['image'], 'image.webp'))).toBe(true)
     expect(isHostedSourceUploadCompatible(new File(['raw'], 'image.raw', { type: 'application/octet-stream' }))).toBe(false)
   })
 })

--- a/src/lib/images/hostedSourceCompatibility.ts
+++ b/src/lib/images/hostedSourceCompatibility.ts
@@ -1,9 +1,12 @@
 import { MAX_UPLOAD_SIZE_BYTES } from './uploadValidation'
 
 const HOSTED_SOURCE_MIME_TYPES = new Set([
+  'image/apng',
   'image/avif',
   'image/bmp',
   'image/gif',
+  'image/jpe',
+  'image/jpg',
   'image/jpeg',
   'image/png',
   'image/webp',
@@ -11,6 +14,7 @@ const HOSTED_SOURCE_MIME_TYPES = new Set([
 
 /** Returns whether an unchanged browser File satisfies the hosted-image boundary. */
 export function isHostedSourceUploadCompatible(file: File): boolean {
+  const mime = file.type.trim().toLowerCase()
   return file.size <= MAX_UPLOAD_SIZE_BYTES
-    && HOSTED_SOURCE_MIME_TYPES.has(file.type.toLowerCase())
+    && (mime.length === 0 || HOSTED_SOURCE_MIME_TYPES.has(mime))
 }

--- a/src/lib/images/hostedSourceCompatibility.ts
+++ b/src/lib/images/hostedSourceCompatibility.ts
@@ -1,0 +1,16 @@
+import { MAX_UPLOAD_SIZE_BYTES } from './uploadValidation'
+
+const HOSTED_SOURCE_MIME_TYPES = new Set([
+  'image/avif',
+  'image/bmp',
+  'image/gif',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+])
+
+/** Returns whether an unchanged browser File satisfies the hosted-image boundary. */
+export function isHostedSourceUploadCompatible(file: File): boolean {
+  return file.size <= MAX_UPLOAD_SIZE_BYTES
+    && HOSTED_SOURCE_MIME_TYPES.has(file.type.toLowerCase())
+}

--- a/src/lib/img/resize.test.ts
+++ b/src/lib/img/resize.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { fitWithinPixelBudget } from './resize'
+
+describe('fitWithinPixelBudget', () => {
+  it('keeps images already within the pixel budget', () => {
+    expect(fitWithinPixelBudget(6000, 4000)).toEqual({
+      width: 6000,
+      height: 4000,
+      resized: false,
+    })
+  })
+
+  it('downscales oversized images without changing their aspect ratio', () => {
+    const result = fitWithinPixelBudget(12_000, 8_000)
+
+    expect(result.resized).toBe(true)
+    expect(result.width * result.height).toBeLessThanOrEqual(24_000_000)
+    expect(result.width / result.height).toBeCloseTo(1.5, 3)
+  })
+})

--- a/src/lib/img/resize.test.ts
+++ b/src/lib/img/resize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { fitWithinPixelBudget } from './resize'
+import { fitWithinPixelBudget, shrinkDimensionsForByteBudget } from './resize'
 
 describe('fitWithinPixelBudget', () => {
   it('keeps images already within the pixel budget', () => {
@@ -15,6 +15,15 @@ describe('fitWithinPixelBudget', () => {
 
     expect(result.resized).toBe(true)
     expect(result.width * result.height).toBeLessThanOrEqual(24_000_000)
+    expect(result.width / result.height).toBeCloseTo(1.5, 3)
+  })
+
+  it('estimates a smaller retry canvas for hosted derivatives over 10 MiB', () => {
+    const result = shrinkDimensionsForByteBudget(6000, 4000, 20 * 1024 * 1024, 10 * 1024 * 1024)
+
+    expect(result.resized).toBe(true)
+    expect(result.width).toBeLessThan(6000)
+    expect(result.height).toBeLessThan(4000)
     expect(result.width / result.height).toBeCloseTo(1.5, 3)
   })
 })

--- a/src/lib/img/resize.ts
+++ b/src/lib/img/resize.ts
@@ -1,0 +1,33 @@
+import { MAX_TRANSFORM_PIXELS } from './constants'
+
+export interface PixelBudgetDimensions {
+  width: number
+  height: number
+  resized: boolean
+}
+
+/**
+ * Fits raster dimensions within the browser transform pixel budget.
+ *
+ * The aspect ratio is preserved and dimensions are rounded down so the
+ * resulting allocation never exceeds the requested pixel count.
+ */
+export function fitWithinPixelBudget(
+  width: number,
+  height: number,
+  maxPixels = MAX_TRANSFORM_PIXELS,
+): PixelBudgetDimensions {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width < 1 || height < 1) {
+    throw new Error('Image dimensions are invalid')
+  }
+  if (width * height <= maxPixels) {
+    return { width: Math.trunc(width), height: Math.trunc(height), resized: false }
+  }
+
+  const scale = Math.sqrt(maxPixels / (width * height))
+  return {
+    width: Math.max(1, Math.floor(width * scale)),
+    height: Math.max(1, Math.floor(height * scale)),
+    resized: true,
+  }
+}

--- a/src/lib/img/resize.ts
+++ b/src/lib/img/resize.ts
@@ -6,6 +6,35 @@ export interface PixelBudgetDimensions {
   resized: boolean
 }
 
+/** Estimates a smaller canvas for retrying an encoded asset over its byte limit. */
+export function shrinkDimensionsForByteBudget(
+  width: number,
+  height: number,
+  currentBytes: number,
+  maxBytes: number,
+): PixelBudgetDimensions {
+  if (
+    !Number.isFinite(currentBytes)
+    || !Number.isFinite(maxBytes)
+    || currentBytes < 1
+    || maxBytes < 1
+  ) {
+    throw new Error('Image byte budget is invalid')
+  }
+  if (currentBytes <= maxBytes) {
+    return { width, height, resized: false }
+  }
+
+  // Encoded bytes broadly track pixel count. Leave headroom for codecs whose
+  // compression ratio worsens slightly at a different resolution.
+  const scale = Math.min(0.9, Math.sqrt(maxBytes / currentBytes) * 0.92)
+  return {
+    width: Math.max(1, Math.floor(width * scale)),
+    height: Math.max(1, Math.floor(height * scale)),
+    resized: true,
+  }
+}
+
 /**
  * Fits raster dimensions within the browser transform pixel budget.
  *

--- a/src/lib/img/transform-client.test.ts
+++ b/src/lib/img/transform-client.test.ts
@@ -52,6 +52,7 @@ function workerResult(request: WorkerRequest, overrides: Record<string, unknown>
       thumbnailWidth: 512,
       thumbnailHeight: 384,
       preservedOriginal: false,
+      resizedToPixelBudget: false,
       sourceNotice: null,
       ...overrides,
     },
@@ -93,10 +94,10 @@ describe('transformImageFile', () => {
     expect(result.thumbnailBlob.type).toBe('image/webp')
   })
 
-  it('maps an animated worker result back to the original File', async () => {
+  it('keeps an animated flag while returning its hosted derivative', async () => {
+    const hosted = new Blob(['static-frame'], { type: 'image/webp' })
     FakeWorker.response = request => workerResult(request, {
-      blob: null,
-      mimeType: 'image/gif',
+      blob: hosted,
       preservedOriginal: true,
     })
     const { transformImageFile } = await loadTransformModule()
@@ -104,7 +105,8 @@ describe('transformImageFile', () => {
 
     const result = await transformImageFile(source, 'webp')
 
-    expect(result.blob).toBe(source)
+    expect(result.blob).toBe(hosted)
+    expect(result.preservedOriginal).toBe(true)
     expect(result.thumbnailBlob.type).toBe('image/webp')
   })
 

--- a/src/lib/img/transform-client.ts
+++ b/src/lib/img/transform-client.ts
@@ -16,6 +16,7 @@ export interface TransformImageResult {
   thumbnailWidth: number
   thumbnailHeight: number
   preservedOriginal: boolean
+  resizedToPixelBudget: boolean
   sourceNotice: string | null
 }
 
@@ -136,11 +137,14 @@ function getTransformWorker(): Worker {
       return
     }
     if (pending.mode === 'full' && result.mode === 'full') {
+      if (result.blob === null) {
+        pending.reject(new Error('Image worker did not return a hosted derivative'))
+        scheduleWorkerTermination()
+        return
+      }
       pending.resolve({
         ...result,
-        blob: result.preservedOriginal
-          ? pending.file
-          : (result.blob ?? pending.file),
+        blob: result.blob,
       })
       scheduleWorkerTermination()
       return

--- a/src/lib/img/transform.worker.ts
+++ b/src/lib/img/transform.worker.ts
@@ -1,12 +1,12 @@
 /// <reference lib="webworker" />
 
 import type { TransformImageResult } from './transform-client'
-import { parseUploadImage } from '@/lib/images/uploadValidation'
+import { MAX_UPLOAD_SIZE_BYTES, parseUploadImage } from '@/lib/images/uploadValidation'
 import { isAnimatedRaster } from './animation'
 import { MAX_TRANSFORM_PIXELS, OUTPUT_MIME_TYPE_BY_FORMAT, THUMBNAIL_MAX_EDGE } from './constants'
 import { encodeImage } from './encoders'
 import { extractRawPreview } from './rawPreview'
-import { fitWithinPixelBudget } from './resize'
+import { fitWithinPixelBudget, shrinkDimensionsForByteBudget } from './resize'
 
 const RAW_EXTENSIONS = new Set([
   '3fr',
@@ -30,6 +30,7 @@ const RAW_EXTENSIONS = new Set([
 ])
 
 const NATIVE_METADATA_PROBE_BYTES = 2 * 1024 * 1024
+const MAX_HOSTING_RESIZE_ATTEMPTS = 4
 
 interface FullTransformRequest {
   id: number
@@ -381,6 +382,50 @@ async function encodeCanvas(
   }
 }
 
+async function encodeWithinHostingLimit(
+  initialCanvas: OffscreenCanvas,
+  format: SupportedFormat,
+  quality?: number,
+): Promise<{ blob: Blob, canvas: OffscreenCanvas, resized: boolean }> {
+  let canvas = initialCanvas
+  try {
+    let blob = await encodeCanvas(canvas, format, quality)
+    let resized = false
+
+    for (let attempt = 0; blob.size > MAX_UPLOAD_SIZE_BYTES && attempt < MAX_HOSTING_RESIZE_ATTEMPTS; attempt += 1) {
+      const dimensions = shrinkDimensionsForByteBudget(
+        canvas.width,
+        canvas.height,
+        blob.size,
+        MAX_UPLOAD_SIZE_BYTES,
+      )
+      const nextCanvas = new OffscreenCanvas(dimensions.width, dimensions.height)
+      const context = nextCanvas.getContext('2d')
+      if (!context) {
+        throw new Error('Failed to initialize hosted image resize canvas')
+      }
+      context.drawImage(canvas, 0, 0, dimensions.width, dimensions.height)
+      canvas.width = 1
+      canvas.height = 1
+      canvas = nextCanvas
+      blob = await encodeCanvas(canvas, format, quality)
+      resized = true
+    }
+
+    if (blob.size > MAX_UPLOAD_SIZE_BYTES) {
+      throw new Error('Unable to fit the converted image within the 10 MiB hosting limit')
+    }
+    return { blob, canvas, resized }
+  }
+  catch (error) {
+    if (canvas !== initialCanvas) {
+      canvas.width = 1
+      canvas.height = 1
+    }
+    throw error
+  }
+}
+
 async function transformThumbnailOnly(file: File): Promise<{
   mode: 'thumbnail'
   blob: Blob
@@ -457,43 +502,52 @@ async function transform(request: TransformRequest): Promise<
   }
 
   const decoded = await decodeSource(request.file)
-  const thumbnailDimensions = outputDimensions(decoded.width, decoded.height, THUMBNAIL_MAX_EDGE)
-  const thumbnailCanvas = new OffscreenCanvas(thumbnailDimensions.width, thumbnailDimensions.height)
+  let hostedCanvas = decoded.canvas
+  let thumbnailCanvas: OffscreenCanvas | null = null
   try {
+    const hosted = await encodeWithinHostingLimit(hostedCanvas, request.format, request.quality)
+    hostedCanvas = hosted.canvas
+    const thumbnailDimensions = outputDimensions(hostedCanvas.width, hostedCanvas.height, THUMBNAIL_MAX_EDGE)
+    thumbnailCanvas = new OffscreenCanvas(thumbnailDimensions.width, thumbnailDimensions.height)
     const thumbnailContext = thumbnailCanvas.getContext('2d')
     if (!thumbnailContext) {
       throw new Error('Failed to initialize thumbnail canvas')
     }
-    thumbnailContext.drawImage(decoded.canvas, 0, 0, thumbnailDimensions.width, thumbnailDimensions.height)
+    thumbnailContext.drawImage(hostedCanvas, 0, 0, thumbnailDimensions.width, thumbnailDimensions.height)
     const thumbnailBlob = await encodeCanvas(thumbnailCanvas, 'webp', 72)
-
-    // Animated sources still need a static derivative when the unchanged file
-    // exceeds hosting or pixel limits. The UI can keep the animation for
-    // download while selecting this derivative only for hosting.
-    const hostedBlob = await encodeCanvas(decoded.canvas, request.format, request.quality)
+    const sourceNotice = [
+      decoded.sourceNotice,
+      hosted.resized ? 'Image was resized further to fit the 10 MiB hosting limit.' : null,
+    ].filter((notice): notice is string => notice !== null).join(' ') || null
 
     return {
       mode: 'full',
-      blob: hostedBlob,
+      blob: hosted.blob,
       mimeType: OUTPUT_MIME_TYPE_BY_FORMAT[request.format],
-      width: decoded.width,
-      height: decoded.height,
+      width: hostedCanvas.width,
+      height: hostedCanvas.height,
       sourceWidth: decoded.sourceWidth,
       sourceHeight: decoded.sourceHeight,
       thumbnailBlob,
       thumbnailWidth: thumbnailDimensions.width,
       thumbnailHeight: thumbnailDimensions.height,
       preservedOriginal: decoded.preservedOriginal,
-      resizedToPixelBudget: decoded.resizedToPixelBudget,
-      sourceNotice: decoded.sourceNotice,
+      resizedToPixelBudget: decoded.resizedToPixelBudget || hosted.resized,
+      sourceNotice,
     }
   }
   finally {
     // Resetting dimensions releases browser/GPU backing stores immediately.
     decoded.canvas.width = 1
     decoded.canvas.height = 1
-    thumbnailCanvas.width = 1
-    thumbnailCanvas.height = 1
+    if (hostedCanvas !== decoded.canvas) {
+      hostedCanvas.width = 1
+      hostedCanvas.height = 1
+    }
+    if (thumbnailCanvas !== null) {
+      thumbnailCanvas.width = 1
+      thumbnailCanvas.height = 1
+    }
   }
 }
 

--- a/src/lib/img/transform.worker.ts
+++ b/src/lib/img/transform.worker.ts
@@ -6,6 +6,7 @@ import { isAnimatedRaster } from './animation'
 import { MAX_TRANSFORM_PIXELS, OUTPUT_MIME_TYPE_BY_FORMAT, THUMBNAIL_MAX_EDGE } from './constants'
 import { encodeImage } from './encoders'
 import { extractRawPreview } from './rawPreview'
+import { fitWithinPixelBudget } from './resize'
 
 const RAW_EXTENSIONS = new Set([
   '3fr',
@@ -54,16 +55,11 @@ interface DecodedSource {
   sourceHeight: number
   sourceNotice: string | null
   preservedOriginal: boolean
+  resizedToPixelBudget: boolean
 }
 
 function extensionOf(name: string): string {
   return name.split('.').pop()?.trim().toLowerCase() ?? ''
-}
-
-function assertPixelBudget(width: number, height: number): void {
-  if (width < 1 || height < 1 || width * height > MAX_TRANSFORM_PIXELS) {
-    throw new Error(`Image dimensions exceed the ${MAX_TRANSFORM_PIXELS / 1_000_000} megapixel transform limit`)
-  }
 }
 
 function canvasFromImageData(imageData: ImageData): OffscreenCanvas {
@@ -74,6 +70,77 @@ function canvasFromImageData(imageData: ImageData): OffscreenCanvas {
   }
   context.putImageData(imageData, 0, 0)
   return canvas
+}
+
+function fitCanvasToPixelBudget(canvas: OffscreenCanvas): {
+  canvas: OffscreenCanvas
+  width: number
+  height: number
+  resized: boolean
+} {
+  const dimensions = fitWithinPixelBudget(canvas.width, canvas.height)
+  if (!dimensions.resized) {
+    return { canvas, ...dimensions }
+  }
+
+  const resizedCanvas = new OffscreenCanvas(dimensions.width, dimensions.height)
+  const context = resizedCanvas.getContext('2d')
+  if (!context) {
+    throw new Error('Failed to initialize resized image canvas')
+  }
+  context.drawImage(canvas, 0, 0, dimensions.width, dimensions.height)
+  canvas.width = 1
+  canvas.height = 1
+  return { canvas: resizedCanvas, ...dimensions }
+}
+
+function resizeNotice(resized: boolean): string | null {
+  return resized
+    ? `Image was resized to stay within the ${MAX_TRANSFORM_PIXELS / 1_000_000} megapixel processing limit.`
+    : null
+}
+
+async function tryNativeResizedDecode(
+  file: File,
+  sourceWidth: number,
+  sourceHeight: number,
+): Promise<DecodedSource | null> {
+  const dimensions = fitWithinPixelBudget(sourceWidth, sourceHeight)
+  if (!dimensions.resized) {
+    return null
+  }
+  try {
+    const bitmap = await createImageBitmap(file, {
+      imageOrientation: 'from-image',
+      resizeWidth: dimensions.width,
+      resizeHeight: dimensions.height,
+      resizeQuality: 'high',
+    })
+    try {
+      const canvas = new OffscreenCanvas(bitmap.width, bitmap.height)
+      const context = canvas.getContext('2d')
+      if (!context) {
+        throw new Error('Failed to initialize resized image canvas')
+      }
+      context.drawImage(bitmap, 0, 0)
+      return {
+        canvas,
+        width: bitmap.width,
+        height: bitmap.height,
+        sourceWidth,
+        sourceHeight,
+        sourceNotice: resizeNotice(true),
+        preservedOriginal: false,
+        resizedToPixelBudget: true,
+      }
+    }
+    finally {
+      bitmap.close()
+    }
+  }
+  catch {
+    return null
+  }
 }
 
 async function decodeHeif(file: File): Promise<DecodedSource> {
@@ -95,7 +162,10 @@ async function decodeHeif(file: File): Promise<DecodedSource> {
 
   const width = image.get_width()
   const height = image.get_height()
-  assertPixelBudget(width, height)
+  const nativeResized = await tryNativeResizedDecode(file, width, height)
+  if (nativeResized !== null) {
+    return nativeResized
+  }
   const imageData = new ImageData(width, height)
   await new Promise<void>((resolve, reject) => {
     image.display(imageData, (result) => {
@@ -107,14 +177,16 @@ async function decodeHeif(file: File): Promise<DecodedSource> {
     })
   })
 
+  const fitted = fitCanvasToPixelBudget(canvasFromImageData(imageData))
   return {
-    canvas: canvasFromImageData(imageData),
-    width,
-    height,
+    canvas: fitted.canvas,
+    width: fitted.width,
+    height: fitted.height,
     sourceWidth: width,
     sourceHeight: height,
-    sourceNotice: null,
+    sourceNotice: resizeNotice(fitted.resized),
     preservedOriginal: false,
+    resizedToPixelBudget: fitted.resized,
   }
 }
 
@@ -129,24 +201,27 @@ async function decodeTiff(file: File): Promise<DecodedSource> {
   const taggedWidth = Array.isArray(ifd.t256) ? Number(ifd.t256[0]) : 0
   const taggedHeight = Array.isArray(ifd.t257) ? Number(ifd.t257[0]) : 0
   if (taggedWidth > 0 && taggedHeight > 0) {
-    assertPixelBudget(taggedWidth, taggedHeight)
+    const nativeResized = await tryNativeResizedDecode(file, taggedWidth, taggedHeight)
+    if (nativeResized !== null) {
+      return nativeResized
+    }
   }
-
   UTIF.decodeImage(buffer, ifd)
-  assertPixelBudget(ifd.width, ifd.height)
   const rgba = UTIF.toRGBA8(ifd)
   const pixels = new Uint8ClampedArray(rgba.byteLength)
   pixels.set(rgba)
   const imageData = new ImageData(pixels, ifd.width, ifd.height)
 
+  const fitted = fitCanvasToPixelBudget(canvasFromImageData(imageData))
   return {
-    canvas: canvasFromImageData(imageData),
-    width: ifd.width,
-    height: ifd.height,
-    sourceWidth: ifd.width,
-    sourceHeight: ifd.height,
-    sourceNotice: null,
+    canvas: fitted.canvas,
+    width: fitted.width,
+    height: fitted.height,
+    sourceWidth: taggedWidth > 0 ? taggedWidth : ifd.width,
+    sourceHeight: taggedHeight > 0 ? taggedHeight : ifd.height,
+    sourceNotice: resizeNotice(fitted.resized),
     preservedOriginal: false,
+    resizedToPixelBudget: fitted.resized,
   }
 }
 
@@ -154,23 +229,38 @@ async function decodeRaw(file: File): Promise<DecodedSource> {
   const sourceBytes = new Uint8Array(await file.arrayBuffer())
   try {
     const previewBytes = await extractRawPreview(sourceBytes)
-    const bitmap = await createImageBitmap(new Blob([previewBytes.buffer], { type: 'image/jpeg' }))
+    const previewBlob = new Blob([previewBytes.buffer], { type: 'image/jpeg' })
+    const previewMetadata = parseUploadImage(previewBytes)
+    const requestedDimensions = previewMetadata === null
+      ? null
+      : fitWithinPixelBudget(previewMetadata.width, previewMetadata.height)
+    const bitmap = await createImageBitmap(previewBlob, requestedDimensions?.resized
+      ? {
+          resizeWidth: requestedDimensions.width,
+          resizeHeight: requestedDimensions.height,
+          resizeQuality: 'high',
+        }
+      : undefined)
     try {
-      assertPixelBudget(bitmap.width, bitmap.height)
-      const canvas = new OffscreenCanvas(bitmap.width, bitmap.height)
+      const dimensions = fitWithinPixelBudget(bitmap.width, bitmap.height)
+      const resized = requestedDimensions?.resized === true || dimensions.resized
+      const canvas = new OffscreenCanvas(dimensions.width, dimensions.height)
       const context = canvas.getContext('2d')
       if (!context) {
         throw new Error('Failed to initialize RAW preview canvas')
       }
-      context.drawImage(bitmap, 0, 0)
+      context.drawImage(bitmap, 0, 0, dimensions.width, dimensions.height)
       return {
         canvas,
-        width: bitmap.width,
-        height: bitmap.height,
-        sourceWidth: bitmap.width,
-        sourceHeight: bitmap.height,
-        sourceNotice: 'Hosted image was generated from the RAW embedded JPEG preview.',
+        width: dimensions.width,
+        height: dimensions.height,
+        sourceWidth: previewMetadata?.width ?? bitmap.width,
+        sourceHeight: previewMetadata?.height ?? bitmap.height,
+        sourceNotice: resized
+          ? `Hosted image was generated from the RAW embedded JPEG preview and resized to stay within ${MAX_TRANSFORM_PIXELS / 1_000_000} megapixels.`
+          : 'Hosted image was generated from the RAW embedded JPEG preview.',
         preservedOriginal: false,
+        resizedToPixelBudget: resized,
       }
     }
     finally {
@@ -187,24 +277,38 @@ async function decodeNative(file: File, bytes: Uint8Array): Promise<DecodedSourc
   if (!metadata) {
     throw new Error('Unable to read image dimensions')
   }
-  assertPixelBudget(metadata.width, metadata.height)
-  const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' })
+  const requestedDimensions = fitWithinPixelBudget(metadata.width, metadata.height)
+  const bitmap = await createImageBitmap(file, {
+    imageOrientation: 'from-image',
+    ...(requestedDimensions.resized
+      ? {
+          resizeWidth: requestedDimensions.width,
+          resizeHeight: requestedDimensions.height,
+          resizeQuality: 'high' as const,
+        }
+      : {}),
+  })
   try {
-    assertPixelBudget(bitmap.width, bitmap.height)
-    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height)
+    const dimensions = fitWithinPixelBudget(bitmap.width, bitmap.height)
+    const canvas = new OffscreenCanvas(dimensions.width, dimensions.height)
     const context = canvas.getContext('2d')
     if (!context) {
       throw new Error('Failed to initialize image worker canvas')
     }
-    context.drawImage(bitmap, 0, 0)
+    context.drawImage(bitmap, 0, 0, dimensions.width, dimensions.height)
+    const resized = requestedDimensions.resized || dimensions.resized
+    const animated = isAnimatedRaster(bytes)
     return {
       canvas,
-      width: bitmap.width,
-      height: bitmap.height,
+      width: dimensions.width,
+      height: dimensions.height,
       sourceWidth: metadata.width,
       sourceHeight: metadata.height,
-      sourceNotice: null,
-      preservedOriginal: isAnimatedRaster(bytes),
+      sourceNotice: animated && resized
+        ? 'Animation was kept unchanged because animated resizing would flatten frames.'
+        : resizeNotice(resized),
+      preservedOriginal: animated,
+      resizedToPixelBudget: resized,
     }
   }
   finally {
@@ -250,27 +354,31 @@ async function encodeCanvas(
   quality?: number,
 ): Promise<Blob> {
   const mimeType = OUTPUT_MIME_TYPE_BY_FORMAT[format]
-  const qualityValue = quality === undefined ? undefined : Math.min(1, Math.max(0.1, quality / 100))
-  const nativeBlob = await canvas
-    .convertToBlob({ type: mimeType, quality: qualityValue })
-    .catch(() => null)
-  if (nativeBlob !== null && nativeBlob.type === mimeType) {
-    return nativeBlob
-  }
-
   const context = canvas.getContext('2d')
   if (!context) {
     throw new Error('Failed to read image worker canvas')
   }
-  const encoded = await encodeImage(
-    context.getImageData(0, 0, canvas.width, canvas.height),
-    format,
-    quality,
-  )
-  const bytes = encoded instanceof Uint8Array
-    ? encoded.slice().buffer
-    : encoded
-  return new Blob([bytes], { type: mimeType })
+  try {
+    // Keep the established codec defaults (WebP/JPEG 85, AVIF 50) instead of
+    // browser-specific canvas defaults that commonly produce larger files.
+    const encoded = await encodeImage(
+      context.getImageData(0, 0, canvas.width, canvas.height),
+      format,
+      quality,
+    )
+    const bytes = encoded instanceof Uint8Array
+      ? encoded.slice().buffer
+      : encoded
+    return new Blob([bytes], { type: mimeType })
+  }
+  catch {
+    const qualityValue = quality === undefined ? undefined : Math.min(1, Math.max(0.1, quality / 100))
+    const nativeBlob = await canvas.convertToBlob({ type: mimeType, quality: qualityValue })
+    if (nativeBlob.type !== mimeType) {
+      throw new Error(`Unable to encode image as ${format}`)
+    }
+    return nativeBlob
+  }
 }
 
 async function transformThumbnailOnly(file: File): Promise<{
@@ -359,16 +467,15 @@ async function transform(request: TransformRequest): Promise<
     thumbnailContext.drawImage(decoded.canvas, 0, 0, thumbnailDimensions.width, thumbnailDimensions.height)
     const thumbnailBlob = await encodeCanvas(thumbnailCanvas, 'webp', 72)
 
-    const hostedBlob = decoded.preservedOriginal
-      ? null
-      : await encodeCanvas(decoded.canvas, request.format, request.quality)
+    // Animated sources still need a static derivative when the unchanged file
+    // exceeds hosting or pixel limits. The UI can keep the animation for
+    // download while selecting this derivative only for hosting.
+    const hostedBlob = await encodeCanvas(decoded.canvas, request.format, request.quality)
 
     return {
       mode: 'full',
       blob: hostedBlob,
-      mimeType: decoded.preservedOriginal
-        ? request.file.type
-        : OUTPUT_MIME_TYPE_BY_FORMAT[request.format],
+      mimeType: OUTPUT_MIME_TYPE_BY_FORMAT[request.format],
       width: decoded.width,
       height: decoded.height,
       sourceWidth: decoded.sourceWidth,
@@ -377,6 +484,7 @@ async function transform(request: TransformRequest): Promise<
       thumbnailWidth: thumbnailDimensions.width,
       thumbnailHeight: thumbnailDimensions.height,
       preservedOriginal: decoded.preservedOriginal,
+      resizedToPixelBudget: decoded.resizedToPixelBudget,
       sourceNotice: decoded.sourceNotice,
     }
   }

--- a/src/lib/storage/albumLabel.test.ts
+++ b/src/lib/storage/albumLabel.test.ts
@@ -1,0 +1,29 @@
+import type { AlbumRecord } from './types'
+import { describe, expect, it } from 'vitest'
+import { formatAlbumPath } from './albumLabel'
+
+function album(id: string, name: string, path: string[]): AlbumRecord {
+  return {
+    id,
+    name,
+    path,
+    parentId: path.at(-2) ?? null,
+    depth: path.length - 1,
+    imageCount: 0,
+    bytesUsed: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+describe('formatAlbumPath', () => {
+  it('disambiguates nested albums with a breadcrumb', () => {
+    const albums = [
+      album('alb_root', 'Default', ['alb_root']),
+      album('travel', 'Travel', ['alb_root', 'travel']),
+      album('summer', 'Summer', ['alb_root', 'travel', 'summer']),
+    ]
+
+    expect(formatAlbumPath(albums[2], albums)).toBe('Default / Travel / Summer')
+  })
+})

--- a/src/lib/storage/albumLabel.ts
+++ b/src/lib/storage/albumLabel.ts
@@ -1,0 +1,13 @@
+import type { AlbumRecord } from './types'
+import { ROOT_ALBUM_ID } from './types'
+
+/** Builds a human-readable album breadcrumb from canonical path ids. */
+export function formatAlbumPath(album: AlbumRecord, albums: readonly AlbumRecord[]): string {
+  const namesById = new Map(albums.map(item => [
+    item.id,
+    item.id === ROOT_ALBUM_ID ? 'Default' : item.name,
+  ]))
+  return album.path
+    .map(id => namesById.get(id) ?? id)
+    .join(' / ')
+}

--- a/src/lib/storage/albumsRepo.ts
+++ b/src/lib/storage/albumsRepo.ts
@@ -428,21 +428,22 @@ export async function setDefaultAlbum(
   }
 
   const timestamp = nowMs()
-  await db
-    .update(albumsTable)
-    .set({
-      isDefault: 0,
-      updatedAt: timestamp,
-    })
-    .where(eq(albumsTable.isDefault, 1))
-
-  await db
-    .update(albumsTable)
-    .set({
-      isDefault: 1,
-      updatedAt: timestamp,
-    })
-    .where(eq(albumsTable.id, input.albumId))
+  await db.batch([
+    db
+      .update(albumsTable)
+      .set({
+        isDefault: 0,
+        updatedAt: timestamp,
+      })
+      .where(eq(albumsTable.isDefault, 1)),
+    db
+      .update(albumsTable)
+      .set({
+        isDefault: 1,
+        updatedAt: timestamp,
+      })
+      .where(eq(albumsTable.id, input.albumId)),
+  ])
 
   return buildStorageMetaInternal()
 }

--- a/src/lib/storage/imagesRepo.ts
+++ b/src/lib/storage/imagesRepo.ts
@@ -1,8 +1,12 @@
 import type { SQL } from 'drizzle-orm'
 import type {
   AlbumImageRecord,
+  ImageDateFilter,
+  ImageFormatFilter,
   ImageListSort,
+  ImageOrientationFilter,
   ImageRecord,
+  ImageResolutionFilter,
   ListAlbumImagesInput,
   ListAlbumImagesResult,
 } from '@/lib/storage/types'
@@ -10,6 +14,7 @@ import { and, asc, desc, eq, isNotNull, isNull, sql } from 'drizzle-orm'
 import { getDb } from '@/lib/db/client'
 import { decodeImageListCursor, encodeImageListCursor } from '@/lib/db/cursor'
 import { imagesTable } from '@/lib/db/schema'
+import { IMAGE_LIST_SORTS } from '@/lib/storage/types'
 
 const DEFAULT_IMAGE_PAGE_SIZE = 50
 const IMAGE_PAGE_SIZE_MIN = 10
@@ -24,10 +29,94 @@ function normalizePageSize(value: number | undefined): number {
 }
 
 function normalizeSort(value: ImageListSort | undefined): ImageListSort {
-  if (value === 'createdAt-desc') {
+  if (value !== undefined && IMAGE_LIST_SORTS.includes(value)) {
     return value
   }
   return DEFAULT_IMAGE_LIST_SORT
+}
+
+function normalizeFormat(value: ImageFormatFilter | undefined): ImageFormatFilter {
+  return value ?? 'all'
+}
+
+function normalizeOrientation(value: ImageOrientationFilter | undefined): ImageOrientationFilter {
+  return value ?? 'all'
+}
+
+function normalizeDate(value: ImageDateFilter | undefined): ImageDateFilter {
+  return value ?? 'all'
+}
+
+function normalizeResolution(value: ImageResolutionFilter | undefined): ImageResolutionFilter {
+  return value ?? 'all'
+}
+
+function dateCutoff(value: ImageDateFilter): number | null {
+  const day = 24 * 60 * 60 * 1000
+  switch (value) {
+    case 'all':
+      return null
+    case 'today':
+      return Date.now() - day
+    case '7d':
+      return Date.now() - 7 * day
+    case '30d':
+      return Date.now() - 30 * day
+    case '1y':
+      return Date.now() - 365 * day
+  }
+}
+
+function cursorCondition(sort: ImageListSort, value: number | string, id: string): SQL {
+  const descending = sort.endsWith('-desc')
+  const idComparison = descending
+    ? sql`${imagesTable.id} < ${id}`
+    : sql`${imagesTable.id} > ${id}`
+
+  const expression = (() => {
+    if (sort.startsWith('createdAt-')) {
+      return imagesTable.createdAt
+    }
+    if (sort.startsWith('name-')) {
+      return imagesTable.nameLower
+    }
+    if (sort.startsWith('sizeBytes-')) {
+      return imagesTable.bytes
+    }
+    return imagesTable.ext
+  })()
+  const primaryComparison = descending
+    ? sql`${expression} < ${value}`
+    : sql`${expression} > ${value}`
+  return sql`(${primaryComparison} OR (${expression} = ${value} AND ${idComparison}))`
+}
+
+function imageOrder(sort: ImageListSort): SQL[] {
+  const descending = sort.endsWith('-desc')
+  const order = descending ? desc : asc
+  if (sort.startsWith('createdAt-')) {
+    return [order(imagesTable.createdAt), order(imagesTable.id)]
+  }
+  if (sort.startsWith('name-')) {
+    return [order(imagesTable.nameLower), order(imagesTable.id)]
+  }
+  if (sort.startsWith('sizeBytes-')) {
+    return [order(imagesTable.bytes), order(imagesTable.id)]
+  }
+  return [order(imagesTable.ext), order(imagesTable.id)]
+}
+
+function cursorValue(row: ImageRow, sort: ImageListSort): number | string {
+  if (sort.startsWith('createdAt-')) {
+    return row.createdAt
+  }
+  if (sort.startsWith('name-')) {
+    return row.nameLower
+  }
+  if (sort.startsWith('sizeBytes-')) {
+    return row.bytes
+  }
+  return row.ext
 }
 
 function normalizeQuery(value: string | undefined): string {
@@ -202,6 +291,7 @@ function toAlbumImageRecord(row: ImageRow): AlbumImageRecord {
     height: row.height,
     createdAt: toIsoString(row.createdAt),
     thumbnail: image.thumbnail ?? null,
+    original: image.original ?? null,
   }
 }
 
@@ -301,23 +391,56 @@ export async function listAlbumImages(
   const pageSize = normalizePageSize(input.pageSize)
   const sort = normalizeSort(input.sort)
   const query = normalizeQuery(input.query)
+  const format = normalizeFormat(input.format)
+  const orientation = normalizeOrientation(input.orientation)
+  const date = normalizeDate(input.date)
+  const resolution = normalizeResolution(input.resolution)
   const needle = query.toLowerCase()
   const cursor = input.cursor !== null && input.cursor !== undefined
     ? decodeImageListCursor(input.cursor)
     : null
+  if (cursor !== null && cursor.sort !== sort) {
+    throw new TypeError('Pagination cursor does not match the selected sort')
+  }
 
-  const conditions: SQL[] = [
-    eq(imagesTable.albumId, input.albumId),
-    isNull(imagesTable.deletedAt),
-  ]
+  const conditions: SQL[] = [isNull(imagesTable.deletedAt)]
+  if (!input.allAlbums) {
+    conditions.push(eq(imagesTable.albumId, input.albumId))
+  }
   if (needle.length > 0) {
     conditions.push(sql`instr(${imagesTable.nameLower}, ${needle}) > 0`)
   }
+  if (format !== 'all') {
+    conditions.push(eq(imagesTable.ext, format))
+  }
+  if (orientation === 'landscape') {
+    conditions.push(sql`${imagesTable.width} > ${imagesTable.height}`)
+  }
+  else if (orientation === 'portrait') {
+    conditions.push(sql`${imagesTable.width} < ${imagesTable.height}`)
+  }
+  else if (orientation === 'square') {
+    conditions.push(sql`${imagesTable.width} = ${imagesTable.height}`)
+  }
+  const cutoff = dateCutoff(date)
+  if (cutoff !== null) {
+    conditions.push(sql`${imagesTable.createdAt} >= ${cutoff}`)
+  }
+  const pixelCount = sql`${imagesTable.width} * ${imagesTable.height}`
+  if (resolution === 'under-2mp') {
+    conditions.push(sql`${pixelCount} < 2000000`)
+  }
+  else if (resolution === '2-12mp') {
+    conditions.push(sql`${pixelCount} >= 2000000 AND ${pixelCount} < 12000000`)
+  }
+  else if (resolution === '12-24mp') {
+    conditions.push(sql`${pixelCount} >= 12000000 AND ${pixelCount} <= 24000000`)
+  }
+  else if (resolution === 'over-24mp') {
+    conditions.push(sql`${pixelCount} > 24000000`)
+  }
   if (cursor !== null) {
-    conditions.push(sql`(
-      ${imagesTable.createdAt} < ${cursor.createdAt}
-      OR (${imagesTable.createdAt} = ${cursor.createdAt} AND ${imagesTable.id} < ${cursor.id})
-    )`)
+    conditions.push(cursorCondition(sort, cursor.value, cursor.id))
   }
 
   const rows = await db
@@ -350,7 +473,7 @@ export async function listAlbumImages(
     })
     .from(imagesTable)
     .where(conditions.length > 1 ? and(...conditions) : conditions[0])
-    .orderBy(desc(imagesTable.createdAt), desc(imagesTable.id))
+    .orderBy(...imageOrder(sort))
     .limit(pageSize + 1)
 
   const hasNextPage = rows.length > pageSize
@@ -361,12 +484,16 @@ export async function listAlbumImages(
   return {
     items,
     nextCursor: hasNextPage && lastRow !== undefined
-      ? encodeImageListCursor({ createdAt: lastRow.createdAt, id: lastRow.id })
+      ? encodeImageListCursor({ sort, value: cursorValue(lastRow, sort), id: lastRow.id })
       : null,
     hasNextPage,
     pageSize,
     sort,
     query,
+    format,
+    orientation,
+    date,
+    resolution,
   }
 }
 

--- a/src/lib/storage/r2Repo.ts
+++ b/src/lib/storage/r2Repo.ts
@@ -83,3 +83,8 @@ export async function putImageObject(
 export async function deleteImageObject(bucket: R2Bucket, key: string): Promise<void> {
   await deleteObject(bucket, key)
 }
+
+/** Loads one canonical image object from R2 for authenticated streaming. */
+export async function getImageObject(bucket: R2Bucket, key: string): Promise<R2ObjectBody | null> {
+  return bucket.get(key)
+}

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -6,7 +6,21 @@ export const ROOT_ALBUM_ID = 'alb_root' as const
 export type ISODateString = string
 
 export type ImageSource = 'index-compressed' | 'dashboard-upload'
-export type ImageListSort = 'createdAt-desc'
+export const IMAGE_LIST_SORTS = [
+  'createdAt-desc',
+  'createdAt-asc',
+  'name-asc',
+  'name-desc',
+  'sizeBytes-desc',
+  'sizeBytes-asc',
+  'type-asc',
+  'type-desc',
+] as const
+export type ImageListSort = typeof IMAGE_LIST_SORTS[number]
+export type ImageFormatFilter = 'all' | 'avif' | 'bmp' | 'gif' | 'jpeg' | 'png' | 'webp'
+export type ImageOrientationFilter = 'all' | 'landscape' | 'portrait' | 'square'
+export type ImageDateFilter = 'all' | 'today' | '7d' | '30d' | '1y'
+export type ImageResolutionFilter = 'all' | 'under-2mp' | '2-12mp' | '12-24mp' | 'over-24mp'
 
 /** Global storage counters and defaults derived from D1 tables. */
 export interface StorageMeta {
@@ -86,6 +100,7 @@ export interface AlbumImageRecord {
   height: number | null
   createdAt: ISODateString
   thumbnail: ThumbnailImageAsset | null
+  original: OriginalImageAsset | null
 }
 
 /**
@@ -96,6 +111,8 @@ export interface AlbumImageListItem extends AlbumImageRecord {
   publicUrl: string | null
   /** Small WebP preview URL, falling back to `publicUrl` for legacy rows. */
   thumbnailUrl: string | null
+  /** Authenticated application route for downloading a retained source. */
+  originalDownloadUrl: string | null
 }
 
 /**
@@ -107,6 +124,11 @@ export interface ListAlbumImagesInput {
   pageSize?: number
   sort?: ImageListSort
   query?: string
+  format?: ImageFormatFilter
+  orientation?: ImageOrientationFilter
+  date?: ImageDateFilter
+  resolution?: ImageResolutionFilter
+  allAlbums?: boolean
 }
 
 /**
@@ -119,6 +141,10 @@ export interface ListAlbumImagesResult {
   pageSize: number
   sort: ImageListSort
   query: string
+  format: ImageFormatFilter
+  orientation: ImageOrientationFilter
+  date: ImageDateFilter
+  resolution: ImageResolutionFilter
 }
 
 /**

--- a/src/lib/storage/validators.ts
+++ b/src/lib/storage/validators.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { ROOT_ALBUM_ID } from '@/lib/storage/types'
+import { IMAGE_LIST_SORTS, ROOT_ALBUM_ID } from '@/lib/storage/types'
 
 /**
  * Shared validator for album identifiers.
@@ -51,8 +51,13 @@ export const listImagesSchema = z.object({
   albumId: albumIdSchema,
   cursor: z.string().min(1).nullable().optional(),
   pageSize: z.number().int().min(10).max(200).optional(),
-  sort: z.literal('createdAt-desc').optional(),
+  sort: z.enum(IMAGE_LIST_SORTS).optional(),
   query: z.string().trim().max(120).optional(),
+  format: z.enum(['all', 'avif', 'bmp', 'gif', 'jpeg', 'png', 'webp']).optional(),
+  orientation: z.enum(['all', 'landscape', 'portrait', 'square']).optional(),
+  date: z.enum(['all', 'today', '7d', '30d', '1y']).optional(),
+  resolution: z.enum(['all', 'under-2mp', '2-12mp', '12-24mp', 'over-24mp']).optional(),
+  allAlbums: z.boolean().optional(),
 })
 
 /**

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ApiImagesOriginalRouteImport } from './routes/api.images.original'
 
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
@@ -28,35 +29,44 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiImagesOriginalRoute = ApiImagesOriginalRouteImport.update({
+  id: '/api/images/original',
+  path: '/api/images/original',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/dashboard': typeof DashboardRoute
   '/login': typeof LoginRoute
+  '/api/images/original': typeof ApiImagesOriginalRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/dashboard': typeof DashboardRoute
   '/login': typeof LoginRoute
+  '/api/images/original': typeof ApiImagesOriginalRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/dashboard': typeof DashboardRoute
   '/login': typeof LoginRoute
+  '/api/images/original': typeof ApiImagesOriginalRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/dashboard' | '/login'
+  fullPaths: '/' | '/dashboard' | '/login' | '/api/images/original'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/dashboard' | '/login'
-  id: '__root__' | '/' | '/dashboard' | '/login'
+  to: '/' | '/dashboard' | '/login' | '/api/images/original'
+  id: '__root__' | '/' | '/dashboard' | '/login' | '/api/images/original'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   DashboardRoute: typeof DashboardRoute
   LoginRoute: typeof LoginRoute
+  ApiImagesOriginalRoute: typeof ApiImagesOriginalRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -82,6 +92,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/images/original': {
+      id: '/api/images/original'
+      path: '/api/images/original'
+      fullPath: '/api/images/original'
+      preLoaderRoute: typeof ApiImagesOriginalRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -89,6 +106,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   DashboardRoute: DashboardRoute,
   LoginRoute: LoginRoute,
+  ApiImagesOriginalRoute: ApiImagesOriginalRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,12 +1,16 @@
-import { TanStackDevtools } from '@tanstack/react-devtools'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createRootRoute, HeadContent, Scripts } from '@tanstack/react-router'
-import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
-import { useState } from 'react'
+import { lazy, Suspense, useState } from 'react'
 import { Toaster } from 'sonner'
 import { Footer, Header, ScrollPositionBar } from '@/components/layout'
 
 import appCss from '../styles.css?url'
+
+const DevelopmentDevtools = import.meta.env.DEV
+  ? lazy(async () => ({
+      default: (await import('@/components/devtools/DevelopmentDevtools')).DevelopmentDevtools,
+    }))
+  : null
 
 export const Route = createRootRoute({
   head: () => ({
@@ -53,15 +57,11 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             {children}
           </main>
           <Footer />
-          <TanStackDevtools
-            config={{
-              position: 'bottom-right',
-            }}
-            plugins={[{
-              name: 'Tanstack Router',
-              render: <TanStackRouterDevtoolsPanel />,
-            }]}
-          />
+          {DevelopmentDevtools !== null && (
+            <Suspense fallback={null}>
+              <DevelopmentDevtools />
+            </Suspense>
+          )}
           <Scripts />
         </QueryClientProvider>
       </body>

--- a/src/routes/api.images.original.ts
+++ b/src/routes/api.images.original.ts
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { isAuthed } from '@/lib/auth/guards'
+import { getD1Binding, getR2Binding } from '@/lib/cloudflare/bindings'
+import { buildAttachmentDisposition } from '@/lib/images/download'
+import { getImageRecord } from '@/lib/storage/imagesRepo'
+import { getImageObject } from '@/lib/storage/r2Repo'
+
+export const Route = createFileRoute('/api/images/original')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (!(await isAuthed())) {
+          return new Response('Unauthorized', { status: 401 })
+        }
+
+        const objectKey = new URL(request.url).searchParams.get('objectKey')?.trim() ?? ''
+        if (objectKey.length === 0) {
+          return new Response('Missing image key', { status: 400 })
+        }
+
+        const image = await getImageRecord(getD1Binding(), objectKey)
+        if (image?.original === null || image?.original === undefined) {
+          return new Response('Original image not found', { status: 404 })
+        }
+
+        const object = await getImageObject(getR2Binding(), image.original.objectKey)
+        if (object === null) {
+          return new Response('Original image object not found', { status: 404 })
+        }
+
+        const headers = new Headers({
+          'Cache-Control': 'private, no-store',
+          'Content-Disposition': buildAttachmentDisposition(image.originalName),
+          'Content-Length': String(object.size),
+          'Content-Type': image.original.mime,
+          'X-Content-Type-Options': 'nosniff',
+        })
+        return new Response(object.body, { headers })
+      },
+    },
+  },
+})

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -1,6 +1,15 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { DashboardFeature } from '@/features/dashboard/components/DashboardFeature'
-import { DASHBOARD_PAGE_SIZES, normalizeDashboardQuery } from '@/features/dashboard/lib/urlState'
+import {
+  DASHBOARD_PAGE_SIZES,
+  isDashboardImageDate,
+  isDashboardImageFormat,
+  isDashboardImageOrientation,
+  isDashboardImageResolution,
+  isDashboardImageScope,
+  isDashboardImageSort,
+  normalizeDashboardQuery,
+} from '@/features/dashboard/lib/urlState'
 import { getCurrentUserFn } from '@/functions/auth'
 
 export const Route = createFileRoute('/dashboard')({
@@ -12,6 +21,22 @@ export const Route = createFileRoute('/dashboard')({
       ...(typeof search.page === 'number' && Number.isInteger(search.page) && search.page > 0 ? { page: search.page } : {}),
       ...(DASHBOARD_PAGE_SIZES.includes(search.pageSize as typeof DASHBOARD_PAGE_SIZES[number])
         ? { pageSize: search.pageSize }
+        : {}),
+      ...(isDashboardImageSort(search.sort) ? { sort: search.sort } : {}),
+      ...(isDashboardImageFormat(search.format)
+        ? { format: search.format }
+        : {}),
+      ...(isDashboardImageOrientation(search.orientation)
+        ? { orientation: search.orientation }
+        : {}),
+      ...(isDashboardImageDate(search.date)
+        ? { date: search.date }
+        : {}),
+      ...(isDashboardImageResolution(search.resolution)
+        ? { resolution: search.resolution }
+        : {}),
+      ...(isDashboardImageScope(search.scope)
+        ? { scope: search.scope }
         : {}),
     }
   },


### PR DESCRIPTION
## ✨ Features Updates && 🐛 Bug Fix

### 📌 Description

Restores the original size-efficient client codec path, makes oversized uploads resize safely instead of failing, and completes the Immediate, B06, B08, and B09 backlog work.

### 🔍 Feature Changes

- [x] API update: authenticated retained-original downloads
- [x] UI/UX improvement: all-album search, sort, format, shape, date, and resolution filters
- [x] UI/UX improvement: nested album breadcrumbs and immediate compression loading state
- [x] Storage update: D1 browse indexes in migrations/0007_image_browse_indexes.sql

### 🛠 Bug Fixes

- [x] Restore JSquash codec defaults and retain the source when conversion grows it
- [x] Resize images above 24 MP and retry derivatives above the 10 MiB hosted limit
- [x] Prevent duplicate ZIP names, non-atomic default album switches, and production Devtools bundling
- [x] Keep upload assets, retained originals, thumbnails, and dimensions consistent
- [x] Keep cross-album bulk usage accounting accurate

### ✅ Testing

- pnpm lint
- pnpm exec tsc --noEmit
- pnpm test: 19 files, 57 tests
- pnpm run build
- Fresh local D1 migration run from 0001 through 0007
- Production bundle checked for absence of TanStack Devtools

### UI verification

- Verified a 30 MP PNG is resized within 24 MP and compressed successfully
- Verified a highly efficient AVIF keeps the original when WebP conversion is larger
- Verified Compress shows Processing, disables immediately, and exposes live progress on the next frame
- Verified 375 px layout has no horizontal overflow and the browser console has no errors
- Authenticated dashboard interactions were covered by code review and automated checks; the local browser session did not have an injected auth token

### Risks or follow-ups

- HEIC/TIFF browsers without native resized decoding still need a full RGBA fallback before downscaling and may have a high peak on extreme sources
- RAW hosting continues to use the embedded JPEG preview rather than full RAW development
- Apply migrations/0007_image_browse_indexes.sql before serving the new sort modes

### AGENTS.md Update

- Updated: documented image-list cursor sort/value/id invariant
- Breaking: No
- Migration: apply migrations/0007_image_browse_indexes.sql
- New env var/binding: N/A
- Deprecated pattern: fixed created-at cursor to sort-aware cursor